### PR TITLE
Enable empty input prediction and make list view support smaller width

### DIFF
--- a/shell/AIShell.Kernel/Command/CommandRunner.cs
+++ b/shell/AIShell.Kernel/Command/CommandRunner.cs
@@ -36,6 +36,7 @@ internal class CommandRunner
             new RetryCommand(),
             new HelpCommand(),
             new RenderCommand(),
+            new ReplaceCommand(),
         };
 
         LoadCommands(buildin, Core);

--- a/shell/AIShell.Kernel/Command/ReplaceCommand.cs
+++ b/shell/AIShell.Kernel/Command/ReplaceCommand.cs
@@ -1,0 +1,126 @@
+﻿using System.CommandLine;
+using AIShell.Abstraction;
+using Microsoft.PowerShell;
+
+namespace AIShell.Kernel.Commands;
+
+internal sealed class ReplaceCommand : CommandBase
+{
+    public ReplaceCommand()
+        : base("replace", "Replace placeholders in generated code with real arguments.")
+    {
+        this.SetHandler(ReplaceAction);
+    }
+
+    private void ReplaceAction()
+    {
+        var host = Shell.Host;
+        var options = PSConsoleReadLine.GetOptions();
+        var oldReadLineHelper = options.ReadLineHelper;
+        var oldPredictionView = options.PredictionViewStyle;
+        var oldPredictionSource = options.PredictionSource;
+
+        var newOptions = new SetPSReadLineOption
+        {
+            ReadLineHelper = new PromptHelper(["vm-rg", "function-rg", "psteam-rg", "rg-bbb"]),
+            PredictionSource = PredictionSource.Plugin,
+            PredictionViewStyle = PredictionViewStyle.ListView,
+        };
+
+        try
+        {
+            PSConsoleReadLine.SetOptions(newOptions);
+            host.Write("$resourceGroup: ");
+            string value = PSConsoleReadLine.ReadLine();
+            if (Console.CursorLeft is not 0)
+            {
+                Console.WriteLine();
+            }
+            host.WriteLine("Input: " + value);
+        }
+        finally
+        {
+            newOptions.ReadLineHelper = oldReadLineHelper;
+            newOptions.PredictionSource = oldPredictionSource;
+            newOptions.PredictionViewStyle = oldPredictionView;
+            PSConsoleReadLine.SetOptions(newOptions);
+        }
+    }
+}
+
+internal class PromptHelper : IReadLineHelper
+{
+    private const string GUID = "744123ff-aefe-42e9-b38b-6f5416d4c795";
+
+    private readonly string _predictorName;
+    private readonly Guid _predictorId;
+    private readonly List<string> _candidates;
+
+    internal PromptHelper(List<string> candidates)
+    {
+        _candidates = candidates;
+        _predictorName = "completion";
+        _predictorId = new Guid(GUID);
+    }
+
+    public CommandCompletion CompleteInput(string input, int cursorIndex)
+    {
+        if (_candidates is null || _candidates.Count is 0)
+        {
+            return null;
+        }
+
+        List<CompletionResult> matches = null;
+        foreach (string value in _candidates)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                continue;
+            }
+
+            if (value.StartsWith(input, StringComparison.OrdinalIgnoreCase))
+            {
+                matches ??= [];
+                matches.Add(new CompletionResult(value, value, CompletionResultType.ParameterValue, toolTip: null));
+            }
+        }
+
+        return matches is null ? null : new CommandCompletion(matches, -1, replacementIndex: 0, replacementLength: input.Length);
+    }
+
+    public Task<List<PredictionResult>> PredictInputAsync(string input)
+    {
+        return Task.Run(() => PredictInput(input));
+    }
+
+    private List<PredictionResult> PredictInput(string input)
+    {
+        if (_candidates is null || _candidates.Count is 0)
+        {
+            return null;
+        }
+
+        int index = 0;
+        List<PredictiveSuggestion> suggestions = null;
+        foreach (string value in _candidates)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                continue;
+            }
+
+            if (value.StartsWith(input, StringComparison.OrdinalIgnoreCase))
+            {
+                suggestions ??= [];
+                suggestions.Insert(index++, new PredictiveSuggestion(value));
+            }
+            else if (value.Contains(input, StringComparison.OrdinalIgnoreCase))
+            {
+                suggestions ??= [];
+                suggestions.Add(new PredictiveSuggestion(value));
+            }
+        }
+
+        return suggestions is null ? null : [ new(_predictorId, _predictorName, session: null, suggestions) ];
+    }
+}

--- a/shell/AIShell.Kernel/Shell.cs
+++ b/shell/AIShell.Kernel/Shell.cs
@@ -390,7 +390,7 @@ internal sealed class Shell : IShell
     private void SetReadLineExperience()
     {
         Utils.SetDefaultKeyHandlers();
-        PSConsoleReadLine.GetOptions().RenderHelper = new ReadLineHelper(CommandRunner);
+        PSConsoleReadLine.GetOptions().ReadLineHelper = new ReadLineHelper(CommandRunner);
     }
 
     /// <summary>
@@ -501,7 +501,8 @@ internal sealed class Shell : IShell
 
     private async Task<string> ReadUserInput(int count, CancellationToken cancellationToken)
     {
-        Host.Markup($"[bold green]{_prompt}[/]:{count}> ");
+        string newLine = Console.CursorLeft is 0 ? string.Empty : "\n";
+        Host.Markup($"{newLine}[bold green]{_prompt}[/]:{count}> ");
         string input = PSConsoleReadLine.ReadLine(cancellationToken);
 
         if (string.IsNullOrEmpty(input))
@@ -518,7 +519,8 @@ internal sealed class Shell : IShell
                     string command = $"/{name}";
                     bool confirmed = await Host.PromptForConfirmationAsync(
                         $"Do you mean to run the command {Formatter.InlineCode(command)} instead?",
-                        defaultValue: true);
+                        defaultValue: true,
+                        cancellationToken: CancellationToken.None);
 
                     if (confirmed)
                     {

--- a/shell/AIShell.Kernel/Utility/ReadLineHelper.cs
+++ b/shell/AIShell.Kernel/Utility/ReadLineHelper.cs
@@ -225,6 +225,11 @@ internal class ReadLineHelper : IReadLineHelper
 
     private List<PredictionResult> PredictInput(string input)
     {
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            return null;
+        }
+
         CommandCompletion completion = CompleteInput(input, input.Length);
         if (completion is null || completion.CompletionMatches.Count is 0)
         {

--- a/shell/ReadLine/Cmdlets.cs
+++ b/shell/ReadLine/Cmdlets.cs
@@ -233,22 +233,6 @@ namespace Microsoft.PowerShell
                     }
                 }
             }
-
-            CommandsToValidateScriptBlockArguments = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
-            {
-                "ForEach-Object", "%",
-                "Invoke-Command", "icm",
-                "Measure-Command",
-                "New-Module", "nmo",
-                "Register-EngineEvent",
-                "Register-ObjectEvent",
-                "Register-WMIEvent",
-                "Set-PSBreakpoint", "sbp",
-                "Start-Job", "sajb",
-                "Trace-Command", "trcm",
-                "Use-Transaction",
-                "Where-Object", "?", "where",
-            };
         }
 
         public EditMode EditMode { get; set; }
@@ -313,7 +297,7 @@ namespace Microsoft.PowerShell
         public int DingDuration { get; set; }
         public BellStyle BellStyle { get; set; }
 
-        public IReadLineHelper RenderHelper { get; set; }
+        public IReadLineHelper ReadLineHelper { get; set; }
 
         public bool HistorySearchCaseSensitive { get; set; }
         internal StringComparison HistoryStringComparison => HistorySearchCaseSensitive ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
@@ -727,6 +711,8 @@ namespace Microsoft.PowerShell
             set => _predictionViewStyle = value;
         }
         internal PredictionViewStyle? _predictionViewStyle;
+
+        public IReadLineHelper ReadLineHelper { get; set; }
 
         public Hashtable Colors { get; set; }
     }

--- a/shell/ReadLine/Completion.cs
+++ b/shell/ReadLine/Completion.cs
@@ -319,7 +319,7 @@ namespace Microsoft.PowerShell
             {
                 try
                 {
-                    _tabCompletions = _options.RenderHelper?.CompleteInput(_buffer.ToString(), _current);
+                    _tabCompletions = _options.ReadLineHelper?.CompleteInput(_buffer.ToString(), _current);
 
                     if (_tabCompletions is null || _tabCompletions.CompletionMatches.Count == 0)
                     {

--- a/shell/ReadLine/Options.cs
+++ b/shell/ReadLine/Options.cs
@@ -132,8 +132,16 @@ namespace Microsoft.PowerShell
             }
             if (options._predictionViewStyle.HasValue)
             {
-                Options.PredictionViewStyle = options.PredictionViewStyle;
-                _prediction.SetViewStyle(options.PredictionViewStyle);
+                var newStyle = options.PredictionViewStyle;
+                if (Options.PredictionViewStyle != newStyle)
+                {
+                    Options.PredictionViewStyle = newStyle;
+                    _prediction.SetViewStyle(newStyle);
+                }
+            }
+            if (options.ReadLineHelper is not null)
+            {
+                Options.ReadLineHelper = options.ReadLineHelper;
             }
             if (options.Colors != null)
             {

--- a/shell/ReadLine/Prediction.Entry.cs
+++ b/shell/ReadLine/Prediction.Entry.cs
@@ -108,20 +108,31 @@ namespace Microsoft.PowerShell
                     return _listItemTextSelected;
                 }
 
-                // Calculate the 'SOURCE' portion to be rendered.
-                int sourceStrLen = Source.Length;
-                int sourceWidth = LengthInBufferCells(Source);
-                if (sourceWidth > PredictionListView.SourceMaxWidth)
+                int sourceStrLen, textWidth;
+                if (width >= 50)
                 {
-                    sourceWidth = PredictionListView.SourceMaxWidth;
-                    sourceStrLen = SubstringLengthByCells(Source, sourceWidth - ellipsisLength);
+                    // Calculate the 'SOURCE' portion to be rendered.
+                    sourceStrLen = Source.Length;
+                    int sourceWidth = LengthInBufferCells(Source);
+                    if (sourceWidth > PredictionListView.SourceMaxWidth)
+                    {
+                        sourceWidth = PredictionListView.SourceMaxWidth;
+                        sourceStrLen = SubstringLengthByCells(Source, sourceWidth - ellipsisLength);
+                    }
+
+                    // Calculate the remaining width after deducting the ' [SOURCE]' portion and the leading '> ' part.
+                    // 5 is the length of the decoration characters: "> ", " [", and ']'.
+                    textWidth = width - sourceWidth - 5;
+                }
+                else
+                {
+                    // We skip rendering the source part when width is too small.
+                    sourceStrLen = 0;
+                    // 2 is the length of decoration characters: "> ".
+                    textWidth = width - 2;
                 }
 
-                // Calculate the remaining width after deducting the ' [SOURCE]' portion and the leading '> ' part.
-                // 5 is the length of the decoration characters: "> ", " [", and ']'.
-                int textWidth = width - sourceWidth - 5;
                 string textMetadataColor = _singleton._options._listPredictionColor;
-
                 StringBuilder line = new StringBuilder(capacity: width)
                     .Append(selectionHighlighting)
                     .Append(textMetadataColor)
@@ -388,22 +399,25 @@ namespace Microsoft.PowerShell
                     }
                 }
 
-                line.Append(' ')
-                    .Append('[')
-                    .Append(textMetadataColor);
-
-                if (sourceStrLen == Source.Length)
+                if (sourceStrLen > 0)
                 {
-                    line.Append(Source);
-                }
-                else
-                {
-                    line.Append(Source, 0, sourceStrLen)
-                        .Append(Ellipsis);
-                }
+                    line.Append(' ')
+                        .Append('[')
+                        .Append(textMetadataColor);
 
-                line.EndColorSection(selectionHighlighting)
-                    .Append(']');
+                    if (sourceStrLen == Source.Length)
+                    {
+                        line.Append(Source);
+                    }
+                    else
+                    {
+                        line.Append(Source, 0, sourceStrLen)
+                            .Append(Ellipsis);
+                    }
+
+                    line.EndColorSection(selectionHighlighting)
+                        .Append(']');
+                }
 
                 if (selectionHighlighting is not null)
                 {

--- a/shell/ReadLine/Prediction.Views.cs
+++ b/shell/ReadLine/Prediction.Views.cs
@@ -172,9 +172,9 @@ namespace Microsoft.PowerShell
             /// <summary>
             /// Calls to the prediction API for suggestion results.
             /// </summary>
-            protected void PredictInput()
+            protected void PredictInput(string userInput)
             {
-                _predictionTask = _singleton._options.RenderHelper?.PredictInputAsync(_singleton._buffer.ToString());
+                _predictionTask = _singleton._options.ReadLineHelper?.PredictInputAsync(userInput);
             }
 
             /// <summary>
@@ -213,7 +213,7 @@ namespace Microsoft.PowerShell
             internal const int SourceMaxWidth = 15;
 
             // Minimal window size.
-            internal const int MinWindowWidth = 50;
+            internal const int MinWindowWidth = 30;
             internal const int MinWindowHeight = 5;
 
             // The items to be displayed in the list view.
@@ -390,10 +390,10 @@ namespace Microsoft.PowerShell
                 {
                     if (UsePlugin)
                     {
-                        PredictInput();
+                        PredictInput(userInput);
                     }
 
-                    if (UseHistory)
+                    if (UseHistory && userInput.Length > 0)
                     {
                         _listItems = GetHistorySuggestions(userInput, HistoryMaxCount);
                         if (_listItems?.Count > 0)
@@ -1227,7 +1227,6 @@ namespace Microsoft.PowerShell
                         || _lastInputText.Length > userInput.Length
                         || !_suggestionText.StartsWith(userInput, _singleton._options.HistoryStringComparison);
 
-
                     // The current suggestion was from history and it still applies to the new input. However, the plugin is in use,
                     // so we may need to force refreshing in case the plugin gives more relevant suggestion for the new input. This
                     // is because we favor plugin over history in the inline view.
@@ -1251,10 +1250,10 @@ namespace Microsoft.PowerShell
 
                         if (UsePlugin)
                         {
-                            PredictInput();
+                            PredictInput(userInput);
                         }
 
-                        if (UseHistory)
+                        if (UseHistory && userInput.Length > 0)
                         {
                             _suggestionText = currentSugText ?? GetOneHistorySuggestion(userInput);
                             _predictorId = Guid.Empty;

--- a/shell/ReadLine/Prediction.cs
+++ b/shell/ReadLine/Prediction.cs
@@ -405,12 +405,25 @@ namespace Microsoft.PowerShell
             /// </summary>
             internal void QueryForSuggestion(string userInput)
             {
+                bool IsUnapplicableInput(bool allowEmptyString)
+                {
+                    // When user input is an empty string, it is a prediction based on previous command lines
+                    // that can only be done with a plugin predictor. So don't bother proceeding when plugin
+                    // is currently disabled.
+                    if (allowEmptyString && ActiveView.UsePlugin && userInput == string.Empty)
+                    {
+                        return false;
+                    }
+
+                    return string.IsNullOrWhiteSpace(userInput) || userInput.Contains('\n');
+                }
+
                 if (IsPredictionOn && (_pauseQuery || ActiveView.HasPendingUpdate))
                 {
                     return;
                 }
 
-                if (!IsPredictionOn || string.IsNullOrWhiteSpace(userInput) || userInput.IndexOf('\n') != -1)
+                if (!IsPredictionOn || IsUnapplicableInput(allowEmptyString: true))
                 {
                     ActiveView.Reset();
                     return;

--- a/shell/ReadLine/Render.cs
+++ b/shell/ReadLine/Render.cs
@@ -200,12 +200,17 @@ namespace Microsoft.PowerShell
             ForceRender();
         }
 
-        private void ForceRender()
+        private void ForceRender(bool cancelWhenEmpty = false)
         {
             var defaultColor = VTColorUtils.DefaultColor;
 
             // Geneate a sequence of logical lines with escape sequences for coloring.
             int logicalLineCount = GenerateRender(defaultColor);
+            if (cancelWhenEmpty && logicalLineCount is 1 && _consoleBufferLines[0].Length is 0)
+            {
+                // Nothing to render this time and it's okay to cancel.
+                return;
+            }
 
             // Now write that out (and remember what we did so we can clear previous renders
             // and minimize writing more than necessary on the next render.)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This PR is the preparation work to support the parameter injection scenario.

1. Update the prediction to support empty-string input, and enable prediction fresh into the `ReadLine` call, before user pressing any keystroke.
    - Update `ForceRender` to be able to cancel rendering when it's okay to do so.
1. Update the list view to support smaller terminal width (`MinWindowWidth = 30`), and stop rendering the source part in list items when the terminal width is `< 50`.
1. Fix the prompt when user press <kbd>Ctrl+c</kbd> within `ReadLine` call.
1. Add the `/replace` to validate the changes for the parameter injection scenario. This command is temporary and will be replaced later.
    - I will provide a utility API to assist the argument replacement, then an agent can decide if it want to expose a command to support the argument replacement. The `az-cli` agent will expose such a command, probably named as `/edit`.