### PR TITLE
Support switching agent by tagging an agent's name

### DIFF
--- a/shell/AIShell.Kernel/Command/AgentCommand.cs
+++ b/shell/AIShell.Kernel/Command/AgentCommand.cs
@@ -199,6 +199,12 @@ internal sealed class AgentCommand : CommandBase
         }
     }
 
+    private IEnumerable<string> AgentCompleter(CompletionContext context)
+    {
+        var shell = (Shell)Shell;
+        return shell.Agents.Select(AgentName);
+    }
+
     private static bool HasAnyAgent(Shell shell, Host host)
     {
         if (shell.Agents.Count is 0)
@@ -215,21 +221,15 @@ internal sealed class AgentCommand : CommandBase
         return agent.Impl.Name;
     }
 
-    private static LLMAgent FindAgent(string name, Shell shell)
+    internal static LLMAgent FindAgent(string name, Shell shell)
     {
         return shell.Agents.FirstOrDefault(a => string.Equals(name, a.Impl.Name, StringComparison.OrdinalIgnoreCase));
     }
 
-    private static void AgentNotFound(string name, Shell shell)
+    internal static void AgentNotFound(string name, Shell shell)
     {
         string availableAgentNames = string.Join(", ", shell.Agents.Select(AgentName));
         shell.Host.WriteErrorLine($"Cannot find an agent with the name '{name}'. Available agent(s): {availableAgentNames}.");
-    }
-
-    private IEnumerable<string> AgentCompleter(CompletionContext context)
-    {
-        var shell = (Shell)Shell;
-        return shell.Agents.Select(AgentName);
     }
 }
 

--- a/shell/AIShell.Kernel/LLMAgent.cs
+++ b/shell/AIShell.Kernel/LLMAgent.cs
@@ -9,6 +9,7 @@ internal class LLMAgent
     internal AgentAssemblyLoadContext LoadContext { get; }
     internal bool OrchestratorRoleDisabled { set; get; }
     internal bool AnalyzerRoleDisabled { set; get; }
+    internal string Prompt { set; get; }
 
     internal LLMAgent(ILLMAgent agent, AgentAssemblyLoadContext loadContext)
     {
@@ -17,6 +18,7 @@ internal class LLMAgent
 
         OrchestratorRoleDisabled = false;
         AnalyzerRoleDisabled = false;
+        Prompt = agent.Name;
     }
 
     internal void Display(Host host, string description = null)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Fix #205

Support switching agent by tagging an agent's name:
1. Support `@<agent>` and `@<agent> <query>` to switch to a different agent, or switch and send the query to that agent.
    - For `@<agent>` only, landing page of that agent will be display, just like running `/agent use <agent>`
    - For `@<agent> <query>`, we assume the user already knows about the capabilities of the target agent and thus won't show the landing page of that agent again.
1. The prompt is updated to use the name of the current active agent by default. When `--shell-wrapper` is used at startup, the prompt defined in the `wrapper.json` will be used for the agent declared in the same file. 
1. When no agent is available, the default prompt `aish` will be used.
1. Tab completion and prediction for the `@<agent>` are enabled.