### PR TITLE
Merge the parameter injection prototype into the `azureAgents` branch

### DIFF
--- a/shell/AIShell.Abstraction/IHost.cs
+++ b/shell/AIShell.Abstraction/IHost.cs
@@ -94,6 +94,12 @@ public interface IHost
     void RenderList<T>(T source, IList<IRenderElement<T>> elements);
 
     /// <summary>
+    /// Render a divider with the passed-in text.
+    /// </summary>
+    /// <param name="text">A brief caption for the subsequent section.</param>
+    void RenderDivider(string text);
+
+    /// <summary>
     /// Run an asynchronouse task with a spinner on the console showing the task in progress.
     /// </summary>
     /// <typeparam name="T">The return type of the asynchronouse task.</typeparam>

--- a/shell/AIShell.Abstraction/IHost.cs
+++ b/shell/AIShell.Abstraction/IHost.cs
@@ -106,7 +106,7 @@ public interface IHost
     /// <param name="func">The asynchronouse task.</param>
     /// <param name="status">The status message to be shown.</param>
     /// <returns>The returned result of <paramref name="func"/></returns>
-    Task<T> RunWithSpinnerAsync<T>(Func<Task<T>> func, string status);
+    Task<T> RunWithSpinnerAsync<T>(Func<Task<T>> func, string status, SpinnerKind? spinnerKind);
 
     /// <summary>
     /// Run an asynchronouse task with a spinner on the console showing the task in progress.
@@ -116,12 +116,22 @@ public interface IHost
     /// <param name="func">The asynchronouse task, which can change the status of the spinner.</param>
     /// <param name="status">The initial status message to be shown.</param>
     /// <returns>The returned result of <paramref name="func"/></returns>
-    Task<T> RunWithSpinnerAsync<T>(Func<IStatusContext, Task<T>> func, string status);
+    Task<T> RunWithSpinnerAsync<T>(Func<IStatusContext, Task<T>> func, string status, SpinnerKind? spinnerKind);
 
     /// <summary>
-    /// Run an asynchronouse task with a spinner with the default status message.
+    /// Run an asynchronouse task with the default spinner and the default status message.
     /// </summary>
-    Task<T> RunWithSpinnerAsync<T>(Func<Task<T>> func) => RunWithSpinnerAsync(func, "Generating...");
+    Task<T> RunWithSpinnerAsync<T>(Func<Task<T>> func) => RunWithSpinnerAsync(func, "Generating...", SpinnerKind.Generating);
+
+    /// <summary>
+    /// Run an asynchronouse task with the default spinner and the specified status message.
+    /// </summary>
+    Task<T> RunWithSpinnerAsync<T>(Func<Task<T>> func, string status) => RunWithSpinnerAsync(func, status, SpinnerKind.Generating);
+
+    /// <summary>
+    /// Run an asynchronouse task that allows changing the status message with the default spinner and the specified initial status message.
+    /// </summary>
+    Task<T> RunWithSpinnerAsync<T>(Func<IStatusContext, Task<T>> func, string status) => RunWithSpinnerAsync(func, status, SpinnerKind.Generating);
 
     /// <summary>
     /// Prompt for selection asynchronously.
@@ -179,9 +189,9 @@ public interface IHost
     /// Prompt for the user to input the value for an argument placeholder.
     /// </summary>
     /// <param name="argInfo">Information about the argument placeholder.</param>
-    /// <param name="cancellationToken">Token to cancel operation.</param>
+    /// <param name="printCaption">Indicates if the caption, such as the description and restriction, should be printed.</param>
     /// <returns></returns>
-    string PromptForArgument(ArgumentInfo argInfo, CancellationToken cancellationToken);
+    string PromptForArgument(ArgumentInfo argInfo, bool printCaption);
 }
 
 /// <summary>
@@ -196,18 +206,37 @@ public interface IStatusContext
 }
 
 /// <summary>
+/// Enum type for the kind of spinner to use.
+/// </summary>
+public enum SpinnerKind
+{
+    /// <summary>
+    /// This spinner indicates text is being generated.
+    /// It should be used when generating response in chat.
+    /// This is the default spinner kind used by the host.
+    /// </summary>
+    Generating,
+
+    /// <summary>
+    /// This spinner indicates a general task processing.
+    /// It should be used in all other cases, such as loading data, etc.
+    /// </summary>
+    Processing,
+}
+
+/// <summary>
 /// Information about an argument placeholder.
 /// </summary>
-public sealed class ArgumentInfo
+public class ArgumentInfo
 {
     /// <summary>
     /// Type of the argument data.
     /// </summary>
     public enum DataType
     {
-        String,
-        Int,
-        Bool,
+        @string,
+        @int,
+        @bool,
     }
 
     /// <summary>
@@ -231,17 +260,12 @@ public sealed class ArgumentInfo
     public DataType Type { get; }
 
     /// <summary>
-    /// Gets a value indicating whether the user must choose from the suggestions.
-    /// </summary>
-    public bool MustChooseFromSuggestions { get; }
-
-    /// <summary>
     /// Gets the list of suggestions for the argument.
     /// </summary>
     public IList<string> Suggestions { get; }
 
     public ArgumentInfo(string name, string description, DataType dataType)
-        : this(name, description, restriction: null, dataType, mustChooseFromSuggestions: false, suggestions: null)
+        : this(name, description, restriction: null, dataType, suggestions: null)
     {
     }
 
@@ -250,24 +274,15 @@ public sealed class ArgumentInfo
         string description,
         string restriction,
         DataType dataType,
-        bool mustChooseFromSuggestions,
         IList<string> suggestions)
     {
         ArgumentException.ThrowIfNullOrEmpty(name);
         ArgumentException.ThrowIfNullOrEmpty(description);
 
-        if (mustChooseFromSuggestions && (suggestions is null || suggestions.Count < 2))
-        {
-            throw new ArgumentException(
-                $"A suggestion list with at least 2 items is required when '{nameof(MustChooseFromSuggestions)}' is true.",
-                nameof(suggestions));
-        }
-
         Name = name;
         Description = description;
         Restriction = restriction;
         Type = dataType;
-        MustChooseFromSuggestions = mustChooseFromSuggestions;
         Suggestions = suggestions;
     }
 }

--- a/shell/AIShell.Kernel/Shell.cs
+++ b/shell/AIShell.Kernel/Shell.cs
@@ -562,7 +562,7 @@ internal sealed class Shell : IShell
                     {
                         // Write out the remote query, in the same style as user typing.
                         Host.Markup($"\n>> Remote Query Received:\n");
-                        Host.MarkupLine($"[teal]{input}[/]");
+                        Host.MarkupLine($"[teal]{input.EscapeMarkup()}[/]");
                     }
                     else
                     {

--- a/shell/AIShell.Kernel/Utility/ReadLineHelper.cs
+++ b/shell/AIShell.Kernel/Utility/ReadLineHelper.cs
@@ -266,7 +266,7 @@ internal class PromptHelper : IReadLineHelper
     internal PromptHelper(IList<string> candidates)
     {
         _candidates = candidates;
-        _predictorName = "completion";
+        _predictorName = "suggestion";
         _predictorId = new Guid(GUID);
     }
 

--- a/shell/agents/AIShell.Azure.Agent/AIShell.Azure.Agent.csproj
+++ b/shell/agents/AIShell.Azure.Agent/AIShell.Azure.Agent.csproj
@@ -18,7 +18,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.11.4" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.18.0" />
-    <PackageReference Include="AIShell.Abstraction" Version="0.1.0-alpha.11">
+    <PackageReference Include="AIShell.Abstraction" Version="0.1.0-alpha.12">
       <ExcludeAssets>contentFiles</ExcludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/shell/agents/AIShell.Azure.Agent/AzCLI/AzCLIChatService.cs
+++ b/shell/agents/AIShell.Azure.Agent/AzCLI/AzCLIChatService.cs
@@ -10,7 +10,7 @@ namespace AIShell.Azure.CLI;
 
 internal class AzCLIChatService : IDisposable
 {
-    internal const string Endpoint = "https://azclitools-copilot-dev.azure-api.net/azcli/copilot";
+    internal const string Endpoint = "https://azclitools-copilot-apim-temp.azure-api.net/azcli/copilot";
 
     private readonly HttpClient _client;
     private readonly string[] _scopes;

--- a/shell/agents/AIShell.Azure.Agent/AzCLI/AzCLIChatService.cs
+++ b/shell/agents/AIShell.Azure.Agent/AzCLI/AzCLIChatService.cs
@@ -36,18 +36,6 @@ internal class AzCLIChatService : IDisposable
         _client.Dispose();
     }
 
-    internal void AddResponseToHistory(string response)
-    {
-        if (!string.IsNullOrEmpty(response))
-        {
-            while (_chatHistory.Count > Utils.HistoryCount - 1)
-            {
-                _chatHistory.RemoveAt(0);
-            }
-            _chatHistory.Add(new ChatMessage() { Role = "assistant", Content = response });
-        }
-    }
-
     private string NewCorrelationID()
     {
         _correlationID = Guid.NewGuid().ToString();

--- a/shell/agents/AIShell.Azure.Agent/AzCLI/AzCLISchema.cs
+++ b/shell/agents/AIShell.Azure.Agent/AzCLI/AzCLISchema.cs
@@ -36,3 +36,19 @@ internal class AzCliResponse
     public string Error { get; set; }
     public ResponseData Data { get; set; }
 }
+
+internal class PlaceholderInfo
+{
+    internal PlaceholderInfo(string query, ResponseData data)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(query);
+        ArgumentNullException.ThrowIfNull(data);
+
+        Query = query;
+        Response = data;
+    }
+
+    public string Query { get; set; }
+    public ResponseData Response { get; set; }
+    public List<PlaceholderItem> Placeholders => Response.PlaceholderSet;
+}

--- a/shell/agents/AIShell.Azure.Agent/AzCLI/AzCLISchema.cs
+++ b/shell/agents/AIShell.Azure.Agent/AzCLI/AzCLISchema.cs
@@ -37,18 +37,19 @@ internal class AzCliResponse
     public ResponseData Data { get; set; }
 }
 
-internal class PlaceholderInfo
+internal class ArgumentPlaceholder
 {
-    internal PlaceholderInfo(string query, ResponseData data)
+    internal ArgumentPlaceholder(string query, ResponseData data)
     {
         ArgumentException.ThrowIfNullOrEmpty(query);
         ArgumentNullException.ThrowIfNull(data);
 
         Query = query;
-        Response = data;
+        ResponseData = data;
+        DataRetriever = new(data);
     }
 
     public string Query { get; set; }
-    public ResponseData Response { get; set; }
-    public List<PlaceholderItem> Placeholders => Response.PlaceholderSet;
+    public ResponseData ResponseData { get; set; }
+    public DataRetriever DataRetriever { get; }
 }

--- a/shell/agents/AIShell.Azure.Agent/AzCLI/Command.cs
+++ b/shell/agents/AIShell.Azure.Agent/AzCLI/Command.cs
@@ -1,0 +1,166 @@
+using System.CommandLine;
+using System.Text;
+using System.Text.Json;
+using AIShell.Abstraction;
+
+namespace AIShell.Azure.CLI;
+
+internal sealed class ReplaceCommand : CommandBase
+{
+    private readonly AzCLIAgent _agent;
+    private readonly Dictionary<string, string> _values;
+
+    public ReplaceCommand(AzCLIAgent agent)
+        : base("replace", "Replace argument placeholders in the generated scripts with the real value.")
+    {
+        _agent = agent;
+        _values = [];
+        this.SetHandler(ReplaceAction);
+    }
+
+    private void ReplaceAction()
+    {
+        _values.Clear();
+
+        IHost host = Shell.Host;
+        var pInfo = _agent.PlaceholderInfo;
+
+        if (pInfo is null)
+        {
+            host.WriteErrorLine("No argument placeholder to replace.");
+            return;
+        }
+
+        List<PlaceholderItem> items = pInfo.Placeholders;
+        string subText = items.Count > 1
+            ? $"all {items.Count} argument placeholders"
+            : "the argument placeholder";
+        host.WriteLine($"\nWe'll provide assistance in replacing {subText} and regenerating the result. You can press 'Ctrl+c' to exit the assistance.\n");
+        host.RenderDivider("Input Values");
+        host.WriteLine();
+
+        try
+        {
+            for (int i = 0; i < items.Count; i++)
+            {
+                var item = items[i];
+                var dataType = Enum.Parse<ArgumentInfo.DataType>(item.Type, ignoreCase: true);
+
+                ArgumentInfo argInfo;
+                if (item.ValidValues?.Count > 0)
+                {
+                    argInfo = new ArgumentInfo(item.Name, item.Desc, restriction: null, dataType, mustChooseFromSuggestions: true, item.ValidValues);
+                }
+                else if (item.Name.Contains("resourceGroup", StringComparison.OrdinalIgnoreCase))
+                {
+                    argInfo = new ArgumentInfo(item.Name, item.Desc, restriction: null, dataType, mustChooseFromSuggestions: false, ["testVM-rg", "function-rg", "api-endpoint-rg"]);
+                }
+                else if (item.Name.Contains("adminUser", StringComparison.OrdinalIgnoreCase))
+                {
+                    argInfo = new ArgumentInfo(item.Name, item.Desc, restriction: null, dataType, mustChooseFromSuggestions: false, ["localadmin", "john-test"]);
+                }
+                else if (item.Name.Contains("image", StringComparison.OrdinalIgnoreCase))
+                {
+                    argInfo = new ArgumentInfo(item.Name, item.Desc, restriction: null, dataType, mustChooseFromSuggestions: false, ["UbuntuLTS", "Win10", "Win11", "RedHat"]);
+                }
+                else if (item.Name.Contains("vmSize", StringComparison.OrdinalIgnoreCase))
+                {
+                    argInfo = new ArgumentInfo(item.Name, item.Desc, restriction: null, dataType, mustChooseFromSuggestions: true, ["A0", "A1", "A2", "A3", "A4"]);
+                }
+                else
+                {
+                    argInfo = new ArgumentInfo(item.Name, item.Desc, dataType);
+                }
+
+                host.Write($"{i+1}. ");
+                string value = host.PromptForArgument(argInfo, Shell.CancellationToken);
+
+                if (!string.IsNullOrEmpty(value))
+                {
+                    _values.Add(item.Name, value);
+                }
+
+                host.WriteLine();
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            bool proceed = false;
+            if (_values.Count > 0)
+            {
+                host.WriteLine();
+                proceed = host.PromptForConfirmationAsync(
+                    "Would you like to regenerate with the provided values so far?",
+                    defaultValue: false,
+                    CancellationToken.None).GetAwaiter().GetResult();
+                host.WriteLine();
+            }
+
+            if (!proceed)
+            {
+                return;
+            }
+        }
+
+        if (_values.Count > 0)
+        {
+            host.RenderDivider("Summary");
+            host.WriteLine("\nThe following placeholders will be replace:");
+            host.RenderList(_values);
+
+            host.RenderDivider("Regenerate");
+            host.MarkupLine($"\nQuery: [teal]{pInfo.Query}[/]");
+
+            string answer = host.RunWithSpinnerAsync(Regenerate).GetAwaiter().GetResult();
+            host.RenderFullResponse(answer);
+        }
+        else
+        {
+            host.WriteLine("No value was specified for any of the argument placeholders.");
+        }
+    }
+
+    private async Task<string> Regenerate()
+    {
+        PlaceholderInfo pInfo = _agent.PlaceholderInfo;
+        StringBuilder prompt = new(capacity: pInfo.Query.Length + _values.Count * 15);
+        prompt.Append("Regenerate for the last query using the following values specified for the argument placeholders.\n\n");
+
+        foreach (var entry in _values)
+        {
+            prompt.Append($"{entry.Key}: {entry.Value}\n");
+        }
+
+        ResponseData data = pInfo.Response;
+        foreach (CommandItem command in data.CommandSet)
+        {
+            foreach (var entry in _values)
+            {
+                command.Script = command.Script.Replace(entry.Key, entry.Value, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
+        List<PlaceholderItem> placeholders = pInfo.Placeholders;
+        if (placeholders.Count > _values.Count)
+        {
+            List<PlaceholderItem> newList = new(placeholders.Count - _values.Count);
+            foreach (PlaceholderItem item in placeholders)
+            {
+                if (!_values.ContainsKey(item.Name))
+                {
+                    newList.Add(item);
+                }
+            }
+
+            data.PlaceholderSet = newList;
+        }
+
+        _agent.AddMessageToHistory(prompt.ToString(), fromUser: true);
+        _agent.AddMessageToHistory(JsonSerializer.Serialize(data, Utils.JsonOptions), fromUser: false);
+
+        // We are doing the replacement locally, but want to fake the regeneration.
+        await Task.Delay(2500);
+
+        return _agent.GenerateAnswer(pInfo.Query, data);
+    }
+}

--- a/shell/agents/AIShell.Azure.Agent/AzCLI/Command.cs
+++ b/shell/agents/AIShell.Azure.Agent/AzCLI/Command.cs
@@ -72,11 +72,14 @@ internal sealed class ReplaceCommand : CommandBase
             {
                 var item = items[i];
                 var (command, parameter) = dataRetriever.GetMappedCommand(item.Name);
-                var coloredCmd = SyntaxHighlightAzCommand(command, parameter, item.Name);
+
+                string desc = item.Desc.TrimEnd('.');
+                string coloredCmd = parameter is null ? null : SyntaxHighlightAzCommand(command, parameter, item.Name);
+                string cmdPart = coloredCmd is null ? null : $" [{coloredCmd}]";
 
                 host.WriteLine(item.Type is "string"
-                    ? $"{i+1}. {item.Desc} [{coloredCmd}]"
-                    : $"{i+1}. {item.Desc} [{coloredCmd}]. Value type: {item.Type}");
+                    ? $"{i+1}. {desc}{cmdPart}"
+                    : $"{i+1}. {desc}{cmdPart}. Value type: {item.Type}");
 
                 // Get the task for creating the 'ArgumentInfo' object and show a spinner
                 // if we have to wait for the task to complete.

--- a/shell/agents/AIShell.Azure.Agent/AzCLI/Command.cs
+++ b/shell/agents/AIShell.Azure.Agent/AzCLI/Command.cs
@@ -9,29 +9,56 @@ internal sealed class ReplaceCommand : CommandBase
 {
     private readonly AzCLIAgent _agent;
     private readonly Dictionary<string, string> _values;
+    private readonly HashSet<string> _productNames;
+    private readonly HashSet<string> _environmentNames;
 
     public ReplaceCommand(AzCLIAgent agent)
         : base("replace", "Replace argument placeholders in the generated scripts with the real value.")
     {
         _agent = agent;
         _values = [];
+        _productNames = [];
+        _environmentNames = [];
+
         this.SetHandler(ReplaceAction);
+    }
+
+    private static string SyntaxHighlightAzCommand(string command, string parameter, string placeholder)
+    {
+        const string vtItalic = "\x1b[3m";
+        const string vtCommand = "\x1b[93m";
+        const string vtParameter = "\x1b[90m";
+        const string vtVariable = "\x1b[92m";
+        const string vtFgDefault = "\x1b[39m";
+        const string vtReset = "\x1b[0m";
+
+        StringBuilder cStr = new(capacity: command.Length + parameter.Length + placeholder.Length + 50);
+        cStr.Append(vtItalic)
+            .Append(vtCommand).Append("az").Append(vtFgDefault).Append(command.AsSpan(2)).Append(' ')
+            .Append(vtParameter).Append(parameter).Append(vtFgDefault).Append(' ')
+            .Append(vtVariable).Append(placeholder).Append(vtFgDefault)
+            .Append(vtReset);
+
+        return cStr.ToString();
     }
 
     private void ReplaceAction()
     {
         _values.Clear();
+        _productNames.Clear();
+        _environmentNames.Clear();
 
         IHost host = Shell.Host;
-        var pInfo = _agent.PlaceholderInfo;
+        ArgumentPlaceholder ap = _agent.ArgPlaceholder;
 
-        if (pInfo is null)
+        if (ap is null)
         {
             host.WriteErrorLine("No argument placeholder to replace.");
             return;
         }
 
-        List<PlaceholderItem> items = pInfo.Placeholders;
+        DataRetriever dataRetriever = ap.DataRetriever;
+        List<PlaceholderItem> items = ap.ResponseData.PlaceholderSet;
         string subText = items.Count > 1
             ? $"all {items.Count} argument placeholders"
             : "the argument placeholder";
@@ -44,42 +71,52 @@ internal sealed class ReplaceCommand : CommandBase
             for (int i = 0; i < items.Count; i++)
             {
                 var item = items[i];
-                var dataType = Enum.Parse<ArgumentInfo.DataType>(item.Type, ignoreCase: true);
+                var (command, parameter) = dataRetriever.GetMappedCommand(item.Name);
+                var coloredCmd = SyntaxHighlightAzCommand(command, parameter, item.Name);
 
-                ArgumentInfo argInfo;
-                if (item.ValidValues?.Count > 0)
+                host.WriteLine(item.Type is "string"
+                    ? $"{i+1}. {item.Desc} [{coloredCmd}]"
+                    : $"{i+1}. {item.Desc} [{coloredCmd}]. Value type: {item.Type}");
+
+                // Get the task for creating the 'ArgumentInfo' object and show a spinner
+                // if we have to wait for the task to complete.
+                Task<ArgumentInfo> argInfoTask = dataRetriever.GetArgInfo(item.Name);
+                ArgumentInfo argInfo = argInfoTask.IsCompleted
+                    ? argInfoTask.Result
+                    : host.RunWithSpinnerAsync(
+                        () => WaitForArgInfoAsync(argInfoTask),
+                        status: $"Requesting data for '{item.Name}' ...",
+                        SpinnerKind.Processing).GetAwaiter().GetResult();
+
+                argInfo ??= new ArgumentInfo(item.Name, item.Desc, Enum.Parse<ArgumentInfo.DataType>(item.Type));
+
+                // Write out restriction for this argument if there is any.
+                if (!string.IsNullOrEmpty(argInfo.Restriction))
                 {
-                    argInfo = new ArgumentInfo(item.Name, item.Desc, restriction: null, dataType, mustChooseFromSuggestions: true, item.ValidValues);
-                }
-                else if (item.Name.Contains("resourceGroup", StringComparison.OrdinalIgnoreCase))
-                {
-                    argInfo = new ArgumentInfo(item.Name, item.Desc, restriction: null, dataType, mustChooseFromSuggestions: false, ["testVM-rg", "function-rg", "api-endpoint-rg"]);
-                }
-                else if (item.Name.Contains("adminUser", StringComparison.OrdinalIgnoreCase))
-                {
-                    argInfo = new ArgumentInfo(item.Name, item.Desc, restriction: null, dataType, mustChooseFromSuggestions: false, ["localadmin", "john-test"]);
-                }
-                else if (item.Name.Contains("image", StringComparison.OrdinalIgnoreCase))
-                {
-                    argInfo = new ArgumentInfo(item.Name, item.Desc, restriction: null, dataType, mustChooseFromSuggestions: false, ["UbuntuLTS", "Win10", "Win11", "RedHat"]);
-                }
-                else if (item.Name.Contains("vmSize", StringComparison.OrdinalIgnoreCase))
-                {
-                    argInfo = new ArgumentInfo(item.Name, item.Desc, restriction: null, dataType, mustChooseFromSuggestions: true, ["A0", "A1", "A2", "A3", "A4"]);
-                }
-                else
-                {
-                    argInfo = new ArgumentInfo(item.Name, item.Desc, dataType);
+                    host.WriteLine(argInfo.Restriction);
                 }
 
-                host.Write($"{i+1}. ");
-                string value = host.PromptForArgument(argInfo, Shell.CancellationToken);
+                ArgumentInfoWithNamingRule nameArgInfo = null;
+                if (argInfo is ArgumentInfoWithNamingRule v)
+                {
+                    nameArgInfo = v;
+                    SuggestForResourceName(nameArgInfo.NamingRule, nameArgInfo.Suggestions);
+                }
 
+                // Prompt for argument without printing captions again.
+                string value = host.PromptForArgument(argInfo, printCaption: false);
                 if (!string.IsNullOrEmpty(value))
                 {
                     _values.Add(item.Name, value);
+
+                    if (nameArgInfo is not null && nameArgInfo.NamingRule.TryMatchName(value, out string prodName, out string envName))
+                    {
+                        _productNames.Add(prodName.ToLower());
+                        _environmentNames.Add(envName.ToLower());
+                    }
                 }
 
+                // Write an extra new line.
                 host.WriteLine();
             }
         }
@@ -98,6 +135,7 @@ internal sealed class ReplaceCommand : CommandBase
 
             if (!proceed)
             {
+                host.WriteLine();
                 return;
             }
         }
@@ -109,10 +147,17 @@ internal sealed class ReplaceCommand : CommandBase
             host.RenderList(_values);
 
             host.RenderDivider("Regenerate");
-            host.MarkupLine($"\nQuery: [teal]{pInfo.Query}[/]");
+            host.MarkupLine($"\nQuery: [teal]{ap.Query}[/]");
 
-            string answer = host.RunWithSpinnerAsync(Regenerate).GetAwaiter().GetResult();
-            host.RenderFullResponse(answer);
+            try
+            {
+                string answer = host.RunWithSpinnerAsync(RegenerateAsync).GetAwaiter().GetResult();
+                host.RenderFullResponse(answer);
+            }
+            catch (OperationCanceledException)
+            {
+                // User cancelled the operation.
+            }
         }
         else
         {
@@ -120,10 +165,58 @@ internal sealed class ReplaceCommand : CommandBase
         }
     }
 
-    private async Task<string> Regenerate()
+    private void SuggestForResourceName(NamingRule rule, IList<string> suggestions)
     {
-        PlaceholderInfo pInfo = _agent.PlaceholderInfo;
-        StringBuilder prompt = new(capacity: pInfo.Query.Length + _values.Count * 15);
+        if (_productNames.Count is 0)
+        {
+            return;
+        }
+
+        foreach (string prodName in _productNames)
+        {
+            if (_environmentNames.Count is 0)
+            {
+                suggestions.Add($"{prodName}-{rule.Abbreviation}");
+                continue;
+            }
+
+            foreach (string envName in _environmentNames)
+            {
+                suggestions.Add($"{prodName}-{rule.Abbreviation}-{envName}");
+            }
+        }
+    }
+
+    private async Task<ArgumentInfo> WaitForArgInfoAsync(Task<ArgumentInfo> argInfoTask)
+    {
+        var token = Shell.CancellationToken;
+        var cts = CancellationTokenSource.CreateLinkedTokenSource(token);
+
+        // Do not let the user wait for more than 2 seconds.
+        var delayTask = Task.Delay(2000, cts.Token);
+        var completedTask = await Task.WhenAny(argInfoTask, delayTask);
+
+        if (completedTask == delayTask)
+        {
+            if (delayTask.IsCanceled)
+            {
+                // User cancelled the operation.
+                throw new OperationCanceledException(token);
+            }
+
+            // Timed out. Last try to see if it finished. Otherwise, return null.
+            return argInfoTask.IsCompletedSuccessfully ? argInfoTask.Result : null;
+        }
+
+        // Finished successfully, so we cancel the delay task and return the result.
+        cts.Cancel();
+        return argInfoTask.Result;
+    }
+
+    private async Task<string> RegenerateAsync()
+    {
+        ArgumentPlaceholder ap = _agent.ArgPlaceholder;
+        StringBuilder prompt = new(capacity: ap.Query.Length + _values.Count * 15);
         prompt.Append("Regenerate for the last query using the following values specified for the argument placeholders.\n\n");
 
         foreach (var entry in _values)
@@ -131,7 +224,10 @@ internal sealed class ReplaceCommand : CommandBase
             prompt.Append($"{entry.Key}: {entry.Value}\n");
         }
 
-        ResponseData data = pInfo.Response;
+        // We are doing the replacement locally, but want to fake the regeneration.
+        await Task.Delay(2500, Shell.CancellationToken);
+
+        ResponseData data = ap.ResponseData;
         foreach (CommandItem command in data.CommandSet)
         {
             foreach (var entry in _values)
@@ -140,8 +236,12 @@ internal sealed class ReplaceCommand : CommandBase
             }
         }
 
-        List<PlaceholderItem> placeholders = pInfo.Placeholders;
-        if (placeholders.Count > _values.Count)
+        List<PlaceholderItem> placeholders = data.PlaceholderSet;
+        if (placeholders.Count == _values.Count)
+        {
+            data.PlaceholderSet = null;
+        }
+        else if (placeholders.Count > _values.Count)
         {
             List<PlaceholderItem> newList = new(placeholders.Count - _values.Count);
             foreach (PlaceholderItem item in placeholders)
@@ -158,9 +258,6 @@ internal sealed class ReplaceCommand : CommandBase
         _agent.AddMessageToHistory(prompt.ToString(), fromUser: true);
         _agent.AddMessageToHistory(JsonSerializer.Serialize(data, Utils.JsonOptions), fromUser: false);
 
-        // We are doing the replacement locally, but want to fake the regeneration.
-        await Task.Delay(2500);
-
-        return _agent.GenerateAnswer(pInfo.Query, data);
+        return _agent.GenerateAnswer(ap.Query, data);
     }
 }

--- a/shell/agents/AIShell.Azure.Agent/AzCLI/DataRetriever.cs
+++ b/shell/agents/AIShell.Azure.Agent/AzCLI/DataRetriever.cs
@@ -1,0 +1,759 @@
+using System.Collections.Concurrent;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using AIShell.Abstraction;
+
+namespace AIShell.Azure.CLI;
+
+internal class DataRetriever : IDisposable
+{
+    private static readonly Dictionary<string, NamingRule> s_azNamingRules;
+    private static readonly ConcurrentDictionary<string, Command> s_azStaticDataCache;
+
+    private readonly string _staticDataRoot;
+    private readonly Task _rootTask;
+    private readonly SemaphoreSlim _semaphore;
+    private readonly List<ArgumentPair> _placeholders;
+    private readonly Dictionary<string, ArgumentPair> _placeholderMap;
+
+    private bool _stop;
+
+    static DataRetriever()
+    {
+        List<NamingRule> rules = [
+            new("API Management Service",
+                "apim",
+                "The name only allows alphanumeric characters and hyphens, and the first character must be a letter. Length: 1 to 50 chars.",
+                "az apim create --name",
+                "New-AzApiManagement -Name"),
+
+            new("Function App",
+                "func",
+                "The name only allows alphanumeric characters and hyphens, and cannot start or end with a hyphen. Length: 2 to 60 chars.",
+                "az functionapp create --name",
+                "New-AzFunctionApp -Name"),
+
+            new("App Service Plan",
+                "asp",
+                "The name only allows alphanumeric characters and hyphens. Length: 1 to 60 chars.",
+                "az appservice plan create --name",
+                "New-AzAppServicePlan -Name"),
+
+            new("Web App",
+                "web",
+                "The name only allows alphanumeric characters and hyphens. Length: 2 to 43 chars.",
+                "az webapp create --name",
+                "New-AzWebApp -Name"),
+
+            new("Application Gateway",
+                "agw",
+                "The name only allows alphanumeric characters, underscores, periods, and hyphens. It must start with a letter or number, and end with a letter, number or underscore. Length: 1 - 80 chars.",
+                "az network application-gateway create --name",
+                "New-AzApplicationGateway -Name"),
+
+            new("Application Insights",
+                "ai",
+                "The name only allows alphanumeric characters, underscores, periods, hyphens and parenthesis, and cannot end in a period. Length: 1 to 255 chars.",
+                "az monitor app-insights component create --app",
+                "New-AzApplicationInsights -Name"),
+
+            new("Application Security Group",
+                "asg",
+                "The name only allows alphanumeric characters, underscores, periods, and hyphens. It must start with a letter or number, and end with a letter, number or underscore. Length: 1 to 80 chars.",
+                "az network asg create --name",
+                "New-AzApplicationSecurityGroup -Name"),
+
+            new("Automation Account",
+                "aa",
+                "The name only allows alphanumeric characters and hyphens, and cannot start or end with a hyphen. Length: 6 to 50 chars.",
+                "az automation account create --name",
+                "New-AzAutomationAccount -Name"),
+
+            new("Availability Set",
+                "as",
+                "The name only allows alphanumeric characters, underscores, periods, and hyphens. It must start with a letter or number, and end with a letter, number or underscore. Length: 1 to 80 chars.",
+                "az vm availability-set create --name",
+                "New-AzAvailabilitySet -Name"),
+
+            new("Redis Cache",
+                "redis",
+                "The name only allows alphanumeric characters and hyphens, and cannot start or end with a hyphen. Consecutive hyphens are not allowed. Length: 1 to 63 chars.",
+                "az redis create --name",
+                "New-AzRedisCache -Name"),
+
+            new("Cognitive Service",
+                "cogs",
+                "The name only allows alphanumeric characters and hyphens, and cannot start or end with a hyphen. Length: 2 to 64 chars.",
+                "az cognitiveservices account create --name",
+                "New-AzCognitiveServicesAccount -Name"),
+
+            new("Cosmos DB",
+                "cosmos",
+                "The name only allows lowercase letters, numbers, and hyphens, and cannot start or end with a hyphen. Length: 3 to 44 chars.",
+                "az cosmosdb create --name",
+                "New-AzCosmosDBAccount -Name"),
+
+            new("Event Hubs Namespace",
+                "eh",
+                "The name only allows alphanumeric characters and hyphens. It must start with a letter and end with a letter or number. Length: 6 to 50 chars.",
+                "az eventhubs namespace create --name",
+                "New-AzEventHubNamespace -Name"),
+
+            new("Event Hubs",
+                abbreviation: null,
+                "The name only allows alphanumeric characters, underscores, periods, and hyphens. It must start and end with a letter or number. Length: 1 to 256 chars.",
+                "az eventhubs eventhub create --name",
+                "New-AzEventHub -Name"),
+
+            new("Key Vault",
+                "kv",
+                "The name only allows alphanumeric characters and hyphens. It must start with a letter and end with a letter or number. Consecutive hyphens are not allowed. Length: 3 to 24 chars.",
+                "az keyvault create --name",
+                "New-AzKeyVault -Name"),
+
+            new("Load Balancer",
+                "lb",
+                "The name only allows alphanumeric characters, underscores, periods, and hyphens. It must start with a letter or number, and end with a letter, number or underscore. Length: 1 to 80 chars.",
+                "az network lb create --name",
+                "New-AzLoadBalancer -Name"),
+
+            new("Log Analytics workspace",
+                "la",
+                "The name only allows alphanumeric characters and hyphens, and cannot start or end with a hyphen. Length: 4 to 63 chars.",
+                "az monitor log-analytics workspace create --name",
+                "New-AzOperationalInsightsWorkspace -Name"),
+
+            new("Logic App",
+                "lapp",
+                "The name only allows alphanumeric characters and hyphens, and cannot start or end with a hyphen. Length: 2 to 64 chars.",
+                "az logic workflow create --name",
+                "New-AzLogicApp -Name"),
+
+            new("Machine Learning workspace",
+                "mlw",
+                "The name only allows alphanumeric characters, underscores, and hyphens. It must start with a letter or number. Length: 3 to 33 chars.",
+                "az ml workspace create --name",
+                "New-AzMLWorkspace -Name"),
+
+            new("Network Interface",
+                "nic",
+                "The name only allows alphanumeric characters, underscores, periods, and hyphens. It must start with a letter or number, and end with a letter, number or underscore. Length: 2 to 64 chars.",
+                "az network nic create --name",
+                "New-AzNetworkInterface -Name"),
+
+            new("Network Security Group",
+                "nsg",
+                "The name only allows alphanumeric characters, underscores, periods, and hyphens. It must start with a letter or number, and end with a letter, number or underscore. Length: 2 to 64 chars.",
+                "az network nsg create --name",
+                "New-AzNetworkSecurityGroup -Name"),
+
+            new("Notification Hub Namespace",
+                "nh",
+                "The name only allows alphanumeric characters and hyphens. It must start with a letter and end with a letter or number. Length: 6 to 50 chars.",
+                "az notification-hub namespace create --name",
+                "New-AzNotificationHubsNamespace -Namespace"),
+
+            new("Notification Hub",
+                abbreviation: null,
+                "The name only allows alphanumeric characters, underscores, periods, and hyphens. It must start and end with a letter or number. Length: 1 to 260 chars.",
+                "az notification-hub create --name",
+                "New-AzNotificationHub -Name"),
+
+            new("Public IP address",
+                "pip",
+                "The name only allows alphanumeric characters, underscores, periods, and hyphens. It must start with a letter or number, and end with a letter, number or underscore. Length: 1 to 80 chars.",
+                "az network public-ip create --name",
+                "New-AzPublicIpAddress -Name"),
+
+            new("Resource Group",
+                "rg",
+                "Resource group names can only include alphanumeric, underscore, parentheses, hyphen, period (except at end), and Unicode characters that match the allowed characters. Length: 1 to 90 chars.",
+                "az group create --name",
+                "New-AzResourceGroup -Name"),
+
+            new("Route table",
+                "rt",
+                "The name only allows alphanumeric characters, underscores, periods, and hyphens. It must start and end with a letter or number. Length: 1 to 80 chars.",
+                "az network route-table create --name",
+                "New-AzRouteTable -Name"),
+
+            new("Search Service",
+                "srch",
+                "Service name must only contain lowercase letters, digits or dashes, cannot use dash as the first two or last one characters, and cannot contain consecutive dashes. Length: 2 to 60 chars.",
+                "az search service create --name",
+                "New-AzSearchService -Name"),
+
+            new("Service Bus Namespace",
+                "sb",
+                "The name only allows alphanumeric characters and hyphens. It must start with a letter and end with a letter or number. Length: 6 to 50 chars.",
+                "az servicebus namespace create --name",
+                "New-AzServiceBusNamespace -Name"),
+
+            new("Service Bus queue",
+                abbreviation: null,
+                "The name only allows alphanumeric characters and hyphens. It must start with a letter and end with a letter or number. Length: 6 to 50 chars.",
+                "az servicebus queue create --name",
+                "New-AzServiceBusQueue -Name"),
+
+            new("Azure SQL Managed Instance",
+                "sqlmi",
+                "The name can only contain lowercase letters, numbers and hyphens. It cannot start or end with a hyphen, nor can it have two consecutive hyphens in the third and fourth places of the name. Length: 1 to 63 chars.",
+                "az sql mi create --name",
+                "New-AzSqlInstance -Name"),
+
+            new("SQL Server",
+                "sqldb",
+                "The name can only contain lowercase letters, numbers and hyphens. It cannot start or end with a hyphen, nor can it have two consecutive hyphens in the third and fourth places of the name. Length: 1 to 63 chars.",
+                "az sql server create --name",
+                "New-AzSqlServer -ServerName"),
+
+            new("Storage Container",
+                abbreviation: null,
+                "The name can only contain lowercase letters, numbers and hyphens. It must start with a letter or a number, and each hyphen must be preceded and followed by a non-hyphen character. Length: 3 to 63 chars.",
+                "az storage container create --name",
+                "New-AzStorageContainer -Name"),
+
+            new("Storage Queue",
+                abbreviation: null,
+                "The name can only contain lowercase letters, numbers and hyphens. It must start with a letter or a number, and each hyphen must be preceded and followed by a non-hyphen character. Length: 3 to 63 chars.",
+                "az storage queue create --name",
+                "New-AzStorageQueue -Name"),
+
+            new("Storage Table",
+                abbreviation: null,
+                "The name can only contain letters and numbers, and must start with a letter. Length: 3 to 63 chars.",
+                "az storage table create --name",
+                "New-AzStorageTable -Name"),
+
+            new("Storage File Share",
+                abbreviation: null,
+                "The name can only contain lowercase letters, numbers and hyphens. It must start and end with a letter or number, and cannot contain two consecutive hyphens. Length: 3 to 63 chars.",
+                "az storage share create --name",
+                "New-AzStorageShare -Name"),
+
+            new("Container Registry",
+                "cr",
+                "The name only allows alphanumeric characters. Length: 5 to 50 chars.",
+                "cr<product>[<environment>][<identifier>]",
+                ["crnavigatorprod001", "crhadoopdev001"],
+                "az acr create --name",
+                "New-AzContainerRegistry -Name"),
+
+            new("Storage Account",
+                "st",
+                "The name can only contain lowercase letters and numbers. Length: 3 to 24 chars.",
+                "st<product>[<environment>][<identifier>]",
+                ["stsalesappdataqa", "sthadoopoutputtest"],
+                "az storage account create --name",
+                "New-AzStorageAccount -Name"),
+
+            new("Traffic Manager profile",
+                "tm",
+                "The name only allows alphanumeric characters and hyphens, and cannot start or end with a hyphen. Length: 1 to 63 chars.",
+                "az network traffic-manager profile create --name",
+                "New-AzTrafficManagerProfile -Name"),
+
+            new("Virtual Machine",
+                "vm",
+                @"The name cannot contain special characters \/""[]:|<>+=;,?*@&#%, whitespace, or begin with '_' or end with '.' or '-'. Length: 1 to 64 chars.",
+                "az vm create --name",
+                "New-AzVM -Name"),
+
+            new("Virtual Network Gateway",
+                "vgw",
+                "The name only allows alphanumeric characters, underscores, periods, and hyphens. It must start with a letter or number, and end with a letter, number or underscore. Length: 1 to 80 chars.",
+                "az network vnet-gateway create --name",
+                "New-AzVirtualNetworkGateway -Name"),
+
+            new("Local Network Gateway",
+                "lgw",
+                "The name only allows alphanumeric characters, underscores, periods, and hyphens. It must start with a letter or number, and end with a letter, number or underscore. Length: 1 to 80 chars.",
+                "az network local-gateway create --name",
+                "New-AzLocalNetworkGateway -Name"),
+
+            new("Virtual Network",
+                "vnet",
+                "The name only allows alphanumeric characters, underscores, periods, and hyphens. It must start with a letter or number, and end with a letter, number or underscore. Length: 1 to 80 chars.",
+                "az network vnet create --name",
+                "New-AzVirtualNetwork -Name"),
+
+            new("Subnet",
+                "snet",
+                "The name only allows alphanumeric characters, underscores, periods, and hyphens. It must start with a letter or number, and end with a letter, number or underscore. Length: 1 to 80 chars.",
+                "az network vnet subnet create --name",
+                "Add-AzVirtualNetworkSubnetConfig -Name"),
+
+            new("VPN Connection",
+                "vcn",
+                "The name only allows alphanumeric characters, underscores, periods, and hyphens. It must start with a letter or number, and end with a letter, number or underscore. Length: 1 to 80 chars.",
+                "az network vpn-connection create --name",
+                "New-AzVpnConnection -Name"),
+        ];
+
+        s_azNamingRules = new(capacity: rules.Count * 2, StringComparer.OrdinalIgnoreCase);
+        foreach (var rule in rules)
+        {
+            s_azNamingRules.Add(rule.AzCLICommand, rule);
+            s_azNamingRules.Add(rule.AzPSCommand, rule);
+        }
+
+        s_azStaticDataCache = new(StringComparer.OrdinalIgnoreCase);
+    }
+
+    internal DataRetriever(ResponseData data)
+    {
+        _stop = false;
+        _semaphore = new SemaphoreSlim(3, 3);
+        _staticDataRoot = @"E:\yard\tmp\az-cli-out\az";
+        _placeholders = new(capacity: data.PlaceholderSet.Count);
+        _placeholderMap = new(capacity: _placeholders.Count);
+
+        PairPlaceholders(data);
+        _rootTask = Task.Run(StartProcessing);
+    }
+
+    private void PairPlaceholders(ResponseData data)
+    {
+        var cmds = new Dictionary<string, string>(data.CommandSet.Count);
+
+        foreach (var item in data.PlaceholderSet)
+        {
+            string command = null, parameter = null;
+
+            foreach (var cmd in data.CommandSet)
+            {
+                string script = cmd.Script;
+                if (!cmds.TryGetValue(script, out command))
+                {
+                    int firstParamIndex = script.IndexOf("--");
+                    command = script.AsSpan(0, firstParamIndex).Trim().ToString();
+                    cmds.Add(script, command);
+                }
+
+                int argIndex = script.IndexOf(item.Name, StringComparison.OrdinalIgnoreCase);
+                if (argIndex is -1)
+                {
+                    continue;
+                }
+
+                int paramIndex = script.LastIndexOf("--", argIndex);
+                parameter = script.AsSpan(paramIndex, argIndex - paramIndex).Trim().ToString();
+
+                break;
+            }
+
+            ArgumentPair pair = new(item, command, parameter);
+            _placeholders.Add(pair);
+            _placeholderMap.Add(item.Name, pair);
+        }
+    }
+
+    private void StartProcessing()
+    {
+        foreach (var pair in _placeholders)
+        {
+            if (_stop) { break; }
+
+            _semaphore.Wait();
+
+            if (pair.ArgumentInfo is null)
+            {
+                lock (pair)
+                {
+                    if (pair.ArgumentInfo is null)
+                    {
+                        pair.ArgumentInfo = Task.Factory.StartNew(ProcessOne, pair);
+                        continue;
+                    }
+                }
+            }
+
+            _semaphore.Release();
+        }
+
+        ArgumentInfo ProcessOne(object pair)
+        {
+            try
+            {
+                return CreateArgInfo((ArgumentPair)pair);
+            }
+            finally
+            {
+                _semaphore.Release();
+            }
+        }
+    }
+
+    private ArgumentInfo CreateArgInfo(ArgumentPair pair)
+    {
+        var item = pair.Placeholder;
+        var dataType = Enum.Parse<ArgumentInfo.DataType>(item.Type, ignoreCase: true);
+
+        if (item.ValidValues?.Count > 0)
+        {
+            return new ArgumentInfo(item.Name, item.Desc, restriction: null, dataType, item.ValidValues);
+        }
+
+        string cmdAndParam = $"{pair.Command} {pair.Parameter}";
+        if (s_azNamingRules.TryGetValue(cmdAndParam, out NamingRule rule))
+        {
+            string restriction = rule.PatternText is null
+                ? rule.GeneralRule
+                : $"""
+                     - {rule.GeneralRule}
+                     - Recommended pattern: {rule.PatternText}, e.g. {string.Join(", ", rule.Example)}.
+                    """;
+            return new ArgumentInfoWithNamingRule(item.Name, item.Desc, restriction, rule);
+        }
+
+        if (string.Equals(pair.Parameter, "--name", StringComparison.OrdinalIgnoreCase)
+            && pair.Command.EndsWith(" create", StringComparison.OrdinalIgnoreCase))
+        {
+            // Placeholder is for the new of a new resource to be created, but not in our cache.
+            return new ArgumentInfo(item.Name, item.Desc, dataType);
+        }
+
+        if (_stop) { return null; }
+
+        List<string> suggestions = GetArgValues(pair, out Option option);
+        // If the option's description is less than the placeholder's description in length, then it's
+        // unlikely to provide more information than the latter. In that case, we don't use it.
+        string optionDesc = option?.Description?.Length > item.Desc.Length ? option.Description : null;
+        return new ArgumentInfo(item.Name, item.Desc, optionDesc, dataType, suggestions);
+    }
+
+    private List<string> GetArgValues(ArgumentPair pair, out Option option)
+    {
+        // First, try to get static argument values if they exist.
+        string command = pair.Command;
+        if (!s_azStaticDataCache.TryGetValue(command, out Command commandData))
+        {
+            string[] cmdElements = command.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            string dirPath = _staticDataRoot;
+            for (int i = 1; i < cmdElements.Length - 1; i++)
+            {
+                dirPath = Path.Combine(dirPath, cmdElements[i]);
+            }
+
+            string filePath = Path.Combine(dirPath, cmdElements[^1] + ".json");
+            commandData = File.Exists(filePath)
+                ? JsonSerializer.Deserialize<Command>(File.OpenRead(filePath))
+                : null;
+            s_azStaticDataCache.TryAdd(command, commandData);
+        }
+
+        option = commandData?.FindOption(pair.Parameter);
+        List<string> staticValues = option?.Arguments;
+        if (staticValues?.Count > 0)
+        {
+            return staticValues;
+        }
+
+        if (_stop) { return null; }
+
+        // Then, try to get dynamic argument values using AzCLI tab completion.
+        string commandLine = $"{pair.Command} {pair.Parameter} ";
+        string tempFile = Path.GetTempFileName();
+
+        try
+        {
+            using var process = new Process()
+            {
+                StartInfo = new ProcessStartInfo()
+                {
+                    FileName = @"C:\Program Files\Microsoft SDKs\Azure\CLI2\python.exe",
+                    Arguments = "-Im azure.cli",
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                }
+            };
+
+            var env = process.StartInfo.Environment;
+            env.Add("ARGCOMPLETE_USE_TEMPFILES", "1");
+            env.Add("_ARGCOMPLETE_STDOUT_FILENAME", tempFile);
+            env.Add("COMP_LINE", commandLine);
+            env.Add("COMP_POINT", (commandLine.Length + 1).ToString());
+            env.Add("_ARGCOMPLETE", "1");
+            env.Add("_ARGCOMPLETE_SUPPRESS_SPACE", "0");
+            env.Add("_ARGCOMPLETE_IFS", "\n");
+            env.Add("_ARGCOMPLETE_SHELL", "powershell");
+
+            process.Start();
+            process.WaitForExit();
+
+            string line;
+            using FileStream stream = File.OpenRead(tempFile);
+            if (stream.Length is 0)
+            {
+                // No allowed values for the option.
+                return null;
+            }
+
+            using StreamReader reader = new(stream);
+            List<string> output = [];
+
+            while ((line = reader.ReadLine()) is not null)
+            {
+                if (line.StartsWith('-'))
+                {
+                    // Argument completion generates incorrect results -- options are written into the file instead of argument allowed values.
+                    return null;
+                }
+
+                string value = line.Trim();
+                if (value != string.Empty)
+                {
+                    output.Add(value);
+                }
+            }
+
+            return output.Count > 0 ? output : null;
+        }
+        catch (Win32Exception e)
+        {
+            throw new ApplicationException($"Failed to get allowed values for 'az {commandLine}': {e.Message}", e);
+        }
+        finally
+        {
+            if (File.Exists(tempFile))
+            {
+                File.Delete(tempFile);
+            }
+        }
+    }
+
+    internal (string command, string parameter) GetMappedCommand(string placeholderName)
+    {
+        if (_placeholderMap.TryGetValue(placeholderName, out ArgumentPair pair))
+        {
+            return (pair.Command, pair.Parameter);
+        }
+
+        throw new ArgumentException($"Unknown placeholder name: '{placeholderName}'", nameof(placeholderName));
+    }
+
+    internal Task<ArgumentInfo> GetArgInfo(string placeholderName)
+    {
+        if (_placeholderMap.TryGetValue(placeholderName, out ArgumentPair pair))
+        {
+            if (pair.ArgumentInfo is null)
+            {
+                lock (pair)
+                {
+                    pair.ArgumentInfo ??= Task.Run(() => CreateArgInfo(pair));
+                }
+            }
+
+            return pair.ArgumentInfo;
+        }
+
+        throw new ArgumentException($"Unknown placeholder name: '{placeholderName}'", nameof(placeholderName));
+    }
+
+    public void Dispose()
+    {
+        _stop = true;
+        _rootTask.Wait();
+        _semaphore.Dispose();
+    }
+}
+
+internal class ArgumentPair
+{
+    internal PlaceholderItem Placeholder { get; }
+    internal string Command { get; }
+    internal string Parameter { get; }
+    internal Task<ArgumentInfo> ArgumentInfo { set; get; }
+
+    internal ArgumentPair(PlaceholderItem placeholder, string command, string parameter)
+    {
+        Placeholder = placeholder;
+        Command = command;
+        Parameter = parameter;
+        ArgumentInfo = null;
+    }
+}
+
+internal class ArgumentInfoWithNamingRule : ArgumentInfo
+{
+    internal ArgumentInfoWithNamingRule(string name, string description, string restriction, NamingRule rule)
+        : base(name, description, restriction, DataType.@string, suggestions: [])
+    {
+        ArgumentNullException.ThrowIfNull(rule);
+        NamingRule = rule;
+    }
+
+    internal NamingRule NamingRule { get; }
+}
+
+internal class NamingRule
+{
+    private static readonly string[] s_products = ["salesapp", "bookingweb", "navigator", "hadoop", "sharepoint"];
+    private static readonly string[] s_envs = ["prod", "dev", "qa", "stage", "test"];
+
+    internal string ResourceName { get; }
+    internal string Abbreviation { get; }
+    internal string GeneralRule { get; }
+    internal string PatternText { get; }
+    internal Regex PatternRegex { get; }
+    internal string[] Example { get; }
+
+    internal string AzCLICommand { get; }
+    internal string AzPSCommand { get; }
+
+    internal NamingRule(
+        string resourceName,
+        string abbreviation,
+        string generalRule,
+        string azCLICommand,
+        string azPSCommand)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(resourceName);
+        ArgumentException.ThrowIfNullOrEmpty(generalRule);
+        ArgumentException.ThrowIfNullOrEmpty(azCLICommand);
+        ArgumentException.ThrowIfNullOrEmpty(azPSCommand);
+
+        ResourceName = resourceName;
+        Abbreviation = abbreviation;
+        GeneralRule = generalRule;
+        AzCLICommand = azCLICommand;
+        AzPSCommand = azPSCommand;
+
+        if (abbreviation is not null)
+        {
+            PatternText = $"<product>-{abbreviation}[-<environment>][-<identifier>]";
+            PatternRegex = new Regex($"^(?<prod>[a-zA-Z0-9]+)-{abbreviation}(?:-(?<env>[a-zA-Z0-9]+))?(?:-[a-zA-Z0-9]+)?$", RegexOptions.Compiled);
+
+            string product = s_products[Random.Shared.Next(0, s_products.Length)];
+            int envIndex = Random.Shared.Next(0, s_envs.Length);
+            Example = [$"{product}-{abbreviation}-{s_envs[envIndex]}", $"{product}-{abbreviation}-{s_envs[(envIndex + 1) % s_envs.Length]}"];
+        }
+    }
+
+    internal NamingRule(
+        string resourceName,
+        string abbreviation,
+        string generalRule,
+        string patternText,
+        string[] example,
+        string azCLICommand,
+        string azPSCommand)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(resourceName);
+        ArgumentException.ThrowIfNullOrEmpty(generalRule);
+        ArgumentException.ThrowIfNullOrEmpty(azCLICommand);
+        ArgumentException.ThrowIfNullOrEmpty(azPSCommand);
+
+        ResourceName = resourceName;
+        Abbreviation = abbreviation;
+        GeneralRule = generalRule;
+        PatternText = patternText;
+        PatternRegex = null;
+        Example = example;
+
+        AzCLICommand = azCLICommand;
+        AzPSCommand = azPSCommand;
+    }
+
+    internal bool TryMatchName(string name, out string prodName, out string envName)
+    {
+        prodName = envName = null;
+        if (PatternRegex is null)
+        {
+            return false;
+        }
+
+        Match match = PatternRegex.Match(name);
+        if (match.Success)
+        {
+            prodName = match.Groups["prod"].Value;
+            envName = match.Groups["env"].Value;
+            return true;
+        }
+
+        return false;
+    }
+}
+
+public class Option
+{
+    public string Name { get; }
+    public string[] Alias { get; }
+    public string[] Short { get; }
+    public string Attribute { get; }
+    public string Description { get; set; }
+    public List<string> Arguments { get; set; }
+
+    public Option(string name, string description, string[] alias, string[] @short, string attribute, List<string> arguments)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+        ArgumentException.ThrowIfNullOrEmpty(description);
+
+        Name = name;
+        Alias = alias;
+        Short = @short;
+        Attribute = attribute;
+        Description = description;
+        Arguments = arguments;
+    }
+}
+
+public sealed class Command
+{
+    public List<Option> Options { get; }
+    public string Examples { get; }
+    public string Name { get; }
+    public string Description { get; }
+
+    public Command(string name, string description, List<Option> options, string examples)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(name);
+        ArgumentException.ThrowIfNullOrEmpty(description);
+        ArgumentNullException.ThrowIfNull(options);
+
+        Options = options;
+        Examples = examples;
+        Name = name;
+        Description = description;
+    }
+
+    public Option FindOption(string name)
+    {
+        foreach (Option option in Options)
+        {
+            if (name.StartsWith("--"))
+            {
+                if (string.Equals(option.Name, name, StringComparison.OrdinalIgnoreCase))
+                {
+                    return option;
+                }
+
+                if (option.Alias is not null)
+                {
+                    foreach (string alias in option.Alias)
+                    {
+                        if (string.Equals(alias, name, StringComparison.OrdinalIgnoreCase))
+                        {
+                            return option;
+                        }
+                    }
+                }
+            }
+            else if (option.Short is not null)
+            {
+                foreach (string s in option.Short)
+                {
+                    if (string.Equals(s, name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return option;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/shell/agents/AIShell.Azure.Agent/AzCLI/UserValueStore.cs
+++ b/shell/agents/AIShell.Azure.Agent/AzCLI/UserValueStore.cs
@@ -1,0 +1,155 @@
+using System.Text;
+
+namespace AIShell.Azure.CLI;
+
+internal class UserValueStore
+{
+    const string PseudoValuePrefix = "__replace_";
+    const string PseudoValueSuffix = "_v__";
+    private int _counter;
+    private readonly Dictionary<string, string> _pseudoToRealValueMap;
+    private readonly Dictionary<string, string> _realToPseudoValueMap;
+
+    internal UserValueStore()
+    {
+        _counter = 0;
+        _pseudoToRealValueMap = [];
+        _realToPseudoValueMap = [];
+    }
+
+    private static bool DigitsOnly(string text, int start, int end)
+    {
+        for (int i = start; i < end; i++)
+        {
+            if (!char.IsDigit(text[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private string GetUniquePseudoValue()
+    {
+        _counter++;
+        return $"{PseudoValuePrefix}{_counter}{PseudoValueSuffix}";
+    }
+
+    internal string SaveUserInputValue(string userValue)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(userValue);
+
+        // We want to have 1:1 mapping between a real value and a pseudo value, so if the user inputs the same
+        // value for 2 different parameters, the server handler will see the same value for those 2 parameters.
+        if (_realToPseudoValueMap.TryGetValue(userValue, out string pseudoValue))
+        {
+            return pseudoValue;
+        }
+
+        pseudoValue = GetUniquePseudoValue();
+        _pseudoToRealValueMap.Add(pseudoValue, userValue);
+        _realToPseudoValueMap.Add(userValue, pseudoValue);
+        return pseudoValue;
+    }
+
+    internal void Clear()
+    {
+        _counter = 0;
+        _pseudoToRealValueMap.Clear();
+        _realToPseudoValueMap.Clear();
+    }
+
+    internal string ReplacePseudoValues(string script)
+    {
+        List<(int Start, int End)> ranges = null;
+
+        int index = script.IndexOf(PseudoValuePrefix);
+        while (index > -1)
+        {
+            int start = index + PseudoValuePrefix.Length;
+            int i2 = script.IndexOf(PseudoValueSuffix, start);
+            if (i2 > -1 && DigitsOnly(script, start, i2))
+            {
+                start = i2 + PseudoValueSuffix.Length;
+                ranges ??= [];
+                ranges.Add((index, start));
+            }
+
+            index = script.IndexOf(PseudoValuePrefix, start);
+        }
+
+        if (ranges is null)
+        {
+            return script;
+        }
+
+        int begin = 0;
+        StringBuilder result = new(capacity: script.Length);
+        foreach (var (start, end) in ranges)
+        {
+            string pseudoValue = script[start..end];
+
+            if (_pseudoToRealValueMap.TryGetValue(pseudoValue, out string realValue))
+            {
+                // We found the corresponding real value.
+                result.Append(script, begin, start - begin).Append(realValue);
+            }
+            else
+            {
+                // No corresponding real value.
+                result.Append(script, begin, end - begin);
+            }
+
+            begin = end;
+        }
+
+        // Append the rest of the original script.
+        if (begin != script.Length)
+        {
+            result.Append(script, begin, script.Length - begin);
+        }
+
+        return result.ToString();
+    }
+
+    internal static void FilterOutPseudoValues(ResponseData data)
+    {
+        List<PlaceholderItem> phList = data.PlaceholderSet;
+        if (phList is null || phList.Count is 0)
+        {
+            return;
+        }
+
+        List<int> indices = null;
+        int minLength = PseudoValuePrefix.Length + PseudoValueSuffix.Length;
+
+        for (int i = 0; i < phList.Count; i++)
+        {
+            string name = phList[i].Name;
+            if (name.StartsWith('$'))
+            {
+                continue;
+            }
+
+            // Check if the name is actually a pseudo value.
+            if (name.Length > minLength
+                && name.StartsWith(PseudoValuePrefix, StringComparison.OrdinalIgnoreCase)
+                && name.EndsWith(PseudoValueSuffix, StringComparison.OrdinalIgnoreCase)
+                && DigitsOnly(name, PseudoValuePrefix.Length, name.Length - PseudoValueSuffix.Length))
+            {
+                indices ??= [];
+                indices.Add(i);
+            }
+        }
+
+        // Remove pseudo values from the placeholder set if there is any.
+        if (indices is not null)
+        {
+            for (int i = indices.Count - 1; i >= 0; i--)
+            {
+                phList.RemoveAt(indices[i]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Merge the parameter injection prototype into the `azureAgents` branch, to reduce the maintenance complexity.
1. Add the `/replace` command
1. Retrieve data locally with 2 tiers of data source to assist user to input values for placeholders.
    - The 1st tier is the cache data generated from parsing the AzCLI help content. We the description and static values for a parameter from this data source.
    - The 2nd tier is the AzCLI tab completion, to get the dynamic values for a parameter, such as `--resource-group`.
1. Fix a bug when handling remote query.
1. Fix the data retrieval code to handle the case when the generated command is not AzCLI command
1. Send pseudo values to the server handler instead of real values from user to avoid any privacy issue. After receiving response, the agent will replace all pseudo values with the real values before displaying to the user.
