### PR TITLE
Support syntax highlighting for AIShell read-line experience

### DIFF
--- a/shell/ReadLine/PublicAPI.cs
+++ b/shell/ReadLine/PublicAPI.cs
@@ -14,6 +14,7 @@ namespace Microsoft.PowerShell
     {
         CommandCompletion CompleteInput(string input, int cursorIndex);
         Task<List<PredictionResult>> PredictInputAsync(string input);
+        string GetSyntaxHighlightingColor(string input, int index);
     }
 
     namespace Internal

--- a/shell/ReadLine/Render.cs
+++ b/shell/ReadLine/Render.cs
@@ -241,14 +241,14 @@ namespace Microsoft.PowerShell
             var text = _buffer.ToString();
             _prediction.QueryForSuggestion(text);
 
-            string color = defaultColor;
+            string color;
             string activeColor = string.Empty;
             int currentLogicalLine = 0;
             bool inSelectedRegion = false;
 
             void UpdateColorsIfNecessary(string newColor)
             {
-                if (!object.ReferenceEquals(newColor, activeColor))
+                if (!ReferenceEquals(newColor, activeColor))
                 {
                     if (!inSelectedRegion)
                     {
@@ -338,6 +338,7 @@ namespace Microsoft.PowerShell
                     inSelectedRegion = false;
                 }
 
+                color = _options.ReadLineHelper?.GetSyntaxHighlightingColor(text, i) ?? defaultColor;
                 var charToRender = text[i];
                 var toEmphasize = i >= _emphasisStart && i < (_emphasisStart + _emphasisLength);
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Support syntax highlighting for AIShell read-line experience:
1. For a command, the command name, parameter, argument are syntax highlighted
   
   ![image](https://github.com/user-attachments/assets/69029787-5d32-4c75-99c8-d924a6531d3c)

1. For tagging an agent, the '@' mention is highlighted

   ![image](https://github.com/user-attachments/assets/d3518e99-2bc6-4c2c-97ae-f9734e112a97)

