### PR TITLE
Update the color for markdown inline code and AIShell command

### DIFF
--- a/shell/AIShell.Kernel/Shell.cs
+++ b/shell/AIShell.Kernel/Shell.cs
@@ -149,7 +149,7 @@ internal sealed class Shell : IShell
         }
 
         // Write out help.
-        Host.MarkupLine($"Type {Formatter.Command("/help")} for more instructions.")
+        Host.MarkupLine($"Run {Formatter.Command("/help")} for more instructions.")
             .WriteLine();
     }
 
@@ -646,7 +646,7 @@ internal sealed class Shell : IShell
 
                     Host.WriteLine()
                         .MarkupWarningLine("No active agent selected, chat is disabled.")
-                        .MarkupWarningLine($"Run {agentCommand} to select an agent. Type {helpCommand} for more instructions.")
+                        .MarkupWarningLine($"Run {agentCommand} to select an agent, or {helpCommand} for more instructions.")
                         .WriteLine();
                     continue;
                 }

--- a/shell/AIShell.Kernel/Utility/ReadLineHelper.cs
+++ b/shell/AIShell.Kernel/Utility/ReadLineHelper.cs
@@ -13,7 +13,7 @@ internal class ReadLineHelper : IReadLineHelper
 {
     // TODO: these colors should be made configurable.
     const string Agent = "\x1b[96m";
-    const string Command = "\x1b[93m";
+    const string Command = "\x1b[92m";
     const string Parameter = "\x1b[90m";
     const string Argument = "\x1b[39;49m";
 

--- a/shell/Markdown.VT/Render/Inlines/CodeInlineRenderer.cs
+++ b/shell/Markdown.VT/Render/Inlines/CodeInlineRenderer.cs
@@ -12,9 +12,9 @@ internal class CodeInlineRenderer : VTObjectRenderer<CodeInline>
 {
     // Use extended color for background.
     // See https://learn.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences#extended-colors
-    private const string VTStyle = "\x1b[92;48;5;236m";
+    private const string VTStyle = "\x1b[39;48;5;236m";
     private const string VTReset = "\x1b[0m";
-    private const string MarkupStyle = "[rgb(0,195,0) on rgb(48,48,48)]";
+    private const string MarkupStyle = "[default on rgb(48,48,48)]";
     private const string MarkupReset = "[/]";
 
     protected override void Write(VTRenderer renderer, CodeInline obj)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Per the discussion with Hiyo, change to
1. Use foreground default for markdown inline code.
2. Use green for AIShell command, both in text and in read-line syntax highlighting.
