### PR TITLE
A few improvement to parameter injection

### DIFF
--- a/shell/agents/AIShell.Azure.Agent/AzCLI/AzCLISchema.cs
+++ b/shell/agents/AIShell.Azure.Agent/AzCLI/AzCLISchema.cs
@@ -27,6 +27,8 @@ internal class ResponseData
 {
     public string Description { get; set; }
     public List<CommandItem> CommandSet { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public List<PlaceholderItem> PlaceholderSet { get; set; }
 }
 

--- a/shell/agents/AIShell.Azure.Agent/AzCLI/Command.cs
+++ b/shell/agents/AIShell.Azure.Agent/AzCLI/Command.cs
@@ -240,7 +240,7 @@ internal sealed class ReplaceCommand : CommandBase
         }
 
         // We are doing the replacement locally, but want to fake the regeneration.
-        await Task.Delay(2500, Shell.CancellationToken);
+        await Task.Delay(2000, Shell.CancellationToken);
 
         ResponseData data = ap.ResponseData;
         foreach (CommandItem command in data.CommandSet)

--- a/shell/agents/AIShell.Azure.Agent/AzCLI/UserValueStore.cs
+++ b/shell/agents/AIShell.Azure.Agent/AzCLI/UserValueStore.cs
@@ -4,7 +4,7 @@ namespace AIShell.Azure.CLI;
 
 internal class UserValueStore
 {
-    const string PseudoValuePrefix = "__replace_";
+    const string PseudoValuePrefix = "__pseudo_";
     const string PseudoValueSuffix = "_v__";
     private int _counter;
     private readonly Dictionary<string, string> _pseudoToRealValueMap;


### PR DESCRIPTION
### PR Summary

A few improvement to parameter injection

1. Do not include 'placeholderSet' in a history entry when its value is null.
2. Reduce the fake wait time when replacing user values from 2.5s to 2s.
3. Change the format for a pseudo value from `__replace_<cnt>_v__` to `__pseudo_<cnt>_v__` to avoid confusion caused to GPT by the word 'replace'.
