### PR TITLE
Make `Singleton` property and `StartChannelSetup()` method public

### DIFF
--- a/shell/AIShell.Integration/Channel.cs
+++ b/shell/AIShell.Integration/Channel.cs
@@ -51,7 +51,7 @@ public class Channel : IDisposable
         return Singleton ??= new Channel(runspace, psConsoleReadLineType);
     }
 
-    internal static Channel Singleton { get; private set; }
+    public static Channel Singleton { get; private set; }
 
     internal string PSVersion => _runspace.Version.ToString();
 
@@ -79,7 +79,7 @@ public class Channel : IDisposable
         return false;
     }
 
-    internal string StartChannelSetup()
+    public string StartChannelSetup()
     {
         if (_serverPipe is not null)
         {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Make `Singleton` property and `StartChannelSetup()` method from the `AIShell.Integration.Channel` class public, so that a developer can utilize the API to create a pipe for an `aish` to collect to.

