### PR TITLE
Update build to remove the dependency of a local feed

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -60,7 +60,6 @@ function Start-Build
     $agent_dir = Join-Path $shell_dir "agents"
 
     $app_dir = Join-Path $shell_dir "AIShell.App"
-    $pkg_dir = Join-Path $shell_dir "AIShell.Abstraction"
     $module_dir = Join-Path $shell_dir "AIShell.Integration"
 
     $openai_agent_dir = Join-Path $agent_dir "AIShell.OpenAI.Agent"
@@ -69,7 +68,6 @@ function Start-Build
 
     $config = $Configuration.ToLower()
     $out_dir = Join-Path $PSScriptRoot "out"
-    $pkg_out_dir = Join-Path $out_dir "package"
     $app_out_dir = Join-Path $out_dir $config "app"
     $module_out_dir = Join-Path $out_dir $config "module" "AIShell"
     $module_help_dir= Join-Path $PSScriptRoot "docs" "cmdlets"
@@ -85,21 +83,9 @@ function Start-Build
         }
     }
 
-    ## Create the package folder. Build will fail when nuget.config references to non-existing path.
-    if (-not (Test-Path $pkg_out_dir)) {
-        New-Item $pkg_out_dir -ItemType Directory > $null
-    }
-
     Write-Host "`n[Build AI Shell ...]`n" -ForegroundColor Green
     $app_csproj = GetProjectFile $app_dir
     dotnet publish $app_csproj -c $Configuration -o $app_out_dir -r $RID --sc
-
-    if ($LASTEXITCODE -eq 0) {
-        ## Move the nuget package to the package folder.
-        Write-Host "`n[Deploy the NuGet package ...]`n" -ForegroundColor Green
-        $pkg_csproj = GetProjectFile $pkg_dir
-        dotnet pack $pkg_csproj -c $Configuration --no-build -o $pkg_out_dir
-    }
 
     if ($LASTEXITCODE -eq 0 -and $AgentToInclude -contains 'openai-gpt') {
         Write-Host "`n[Build the OpenAI agent ...]`n" -ForegroundColor Green

--- a/shell/AIShell.Abstraction/AIShell.Abstraction.csproj
+++ b/shell/AIShell.Abstraction/AIShell.Abstraction.csproj
@@ -3,22 +3,9 @@
 
   <PropertyGroup>
     <AssemblyName>AIShell.Abstraction</AssemblyName>
-
-    <PackageId>AIShell.Abstraction</PackageId>
-    <Company>Microsoft Corporation</Company>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
-    <Description>The abstraction layer SDK for building a plugin agent for AIShell.</Description>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
-
-  <ItemGroup>
-    <None Include="..\..\README.md" Pack="true" PackagePath="" />
-  </ItemGroup>
-
 </Project>

--- a/shell/AIShell.Integration/AIShell.Integration.csproj
+++ b/shell/AIShell.Integration/AIShell.Integration.csproj
@@ -18,11 +18,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AIShell.Abstraction" Version="0.1.0-alpha.12" />
     <PackageReference Include="System.Management.Automation" Version="7.4.0">
       <ExcludeAssets>contentFiles</ExcludeAssets>
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\AIShell.Abstraction\AIShell.Abstraction.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/shell/agents/AIShell.Interpreter.Agent/AIShell.Interpreter.Agent.csproj
+++ b/shell/agents/AIShell.Interpreter.Agent/AIShell.Interpreter.Agent.csproj
@@ -19,10 +19,15 @@
     <PackageReference Include="Azure.AI.OpenAI" Version="1.0.0-beta.13" />
     <PackageReference Include="Azure.Core" Version="1.37.0" />
     <PackageReference Include="SharpToken" Version="2.0.3" />
-    <PackageReference Include="AIShell.Abstraction" Version="0.1.0-alpha.12">
-      <ExcludeAssets>contentFiles</ExcludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\AIShell.Abstraction\AIShell.Abstraction.csproj">
+      <!-- Disable copying AIShell.Abstraction.dll to output folder -->
+      <Private>false</Private>
+      <!-- Disable copying the transitive dependencies to output folder -->
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </ProjectReference>
   </ItemGroup>
 
 </Project>

--- a/shell/agents/AIShell.Ollama.Agent/AIShell.Ollama.Agent.csproj
+++ b/shell/agents/AIShell.Ollama.Agent/AIShell.Ollama.Agent.csproj
@@ -16,10 +16,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AIShell.Abstraction" Version="0.1.0-alpha.12">
-      <ExcludeAssets>contentFiles</ExcludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+    <ProjectReference Include="..\..\AIShell.Abstraction\AIShell.Abstraction.csproj">
+      <!-- Disable copying AIShell.Abstraction.dll to output folder -->
+      <Private>false</Private>
+      <!-- Disable copying the transitive dependencies to output folder -->
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </ProjectReference>
   </ItemGroup>
 
 </Project>

--- a/shell/agents/AIShell.OpenAI.Agent/AIShell.OpenAI.Agent.csproj
+++ b/shell/agents/AIShell.OpenAI.Agent/AIShell.OpenAI.Agent.csproj
@@ -24,10 +24,15 @@
     <PackageReference Include="Azure.AI.OpenAI" Version="1.0.0-beta.17" />
     <PackageReference Include="Azure.Core" Version="1.39.0" />
     <PackageReference Include="SharpToken" Version="2.0.3" />
-    <PackageReference Include="AIShell.Abstraction" Version="0.1.0-alpha.12">
-      <ExcludeAssets>contentFiles</ExcludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\AIShell.Abstraction\AIShell.Abstraction.csproj">
+      <!-- Disable copying AIShell.Abstraction.dll to output folder -->
+      <Private>false</Private>
+      <!-- Disable copying the transitive dependencies to output folder -->
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </ProjectReference>
   </ItemGroup>
 
 </Project>

--- a/shell/nuget.config
+++ b/shell/nuget.config
@@ -2,7 +2,6 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="LocalPackages" value="..\out\package" />
     <add key="PowerShell_PublicPackages" value="https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

The build was updated so that `AIShell.Integration` and `AIShell.*.Agent` are all depend on the project of `AIShell.Abstraction` instead of the NuGet package of it. In this way, we can get rid of the dependency of a local feed, which is causing CFS issue to this repo.

