### PR TITLE
Remove the `IOrchestrator` and `ICodeAnalyzer` interfaces

### DIFF
--- a/shell/AIShell.Abstraction/ILLMAgent.cs
+++ b/shell/AIShell.Abstraction/ILLMAgent.cs
@@ -138,9 +138,10 @@ public interface ILLMAgent : IDisposable
 
     /// <summary>
     /// Refresh the current chat by starting a new chat session.
-    /// An agent can reset chat states in this method.
+    /// This method allows an agent to reset chat states, interact with user for authentication, print welcome message, and more.
     /// </summary>
-    void RefreshChat();
+    /// <param name="shell">The interface for interacting with the shell.</param>
+    Task RefreshChatAsync(IShell shell);
 
     /// <summary>
     /// Initiates a chat with the AI, using the provided input and shell.
@@ -148,7 +149,7 @@ public interface ILLMAgent : IDisposable
     /// <param name="input">The query message for the AI.</param>
     /// <param name="shell">The interface for interacting with the shell.</param>
     /// <returns>A task whose result contains a boolean indicating whether the query was successfully served.</returns>
-    Task<bool> Chat(string input, IShell shell);
+    Task<bool> ChatAsync(string input, IShell shell);
 
     /// <summary>
     /// Retrieves the collection of commands to be registered to the shell for the agent.
@@ -168,26 +169,4 @@ public interface ILLMAgent : IDisposable
     /// <param name="action">Type of the action.</param>
     /// <param name="actionPayload"></param>
     void OnUserAction(UserActionPayload actionPayload);
-}
-
-public interface IOrchestrator : ILLMAgent
-{
-    /// <summary>
-    /// Find the most suitable agent to serve the prompt.
-    /// </summary>
-    /// <param name="prompt">User prompt to be send to the agent.</param>
-    /// <param name="agents">List of descriptions for each of the agents</param>
-    /// <returns>The index of the selected agent. Or -1 if none are suitable.</returns>
-    Task<int> FindAgentForPrompt(string prompt, List<string> agents, CancellationToken token);
-}
-
-public interface ICodeAnalyzer : ILLMAgent
-{
-    /// <summary>
-    /// Analyze code blocks for any security concerns.
-    /// </summary>
-    /// <param name="codeBlocks"></param>
-    /// <param name="shell"></param>
-    /// <returns></returns>
-    Task<bool> AnalyzeCode(List<string> codeBlocks, IShell shell);
 }

--- a/shell/AIShell.Kernel/Command/AgentCommand.cs
+++ b/shell/AIShell.Kernel/Command/AgentCommand.cs
@@ -19,9 +19,6 @@ internal sealed class AgentCommand : CommandBase
         use.AddArgument(useAgent);
         use.SetHandler(UseAgentAction, useAgent);
 
-        var pop = new Command("pop", "Pop the current active agent off the stack and go back to the orchestrator agent.");
-        pop.SetHandler(PopAgentAction);
-
         var config = new Command("config", "Open up the setting file for an agent. When no agent is specified, target the active agent.");
         var editor = new Option<string>("--editor", "The editor to open the setting file in.");
         var configAgent = new Argument<string>(
@@ -37,7 +34,6 @@ internal sealed class AgentCommand : CommandBase
 
         AddCommand(config);
         AddCommand(list);
-        AddCommand(pop);
         AddCommand(use);
     }
 
@@ -89,25 +85,6 @@ internal sealed class AgentCommand : CommandBase
         shell.SwitchActiveAgent(chosenAgent);
         host.MarkupLine($"Using the agent [green]{chosenAgent.Impl.Name}[/]:");
         chosenAgent.Display(host);
-    }
-
-    private void PopAgentAction()
-    {
-        var shell = (Shell)Shell;
-        var host = shell.Host;
-
-        try
-        {
-            shell.PopActiveAgent();
-
-            var current = shell.ActiveAgent;
-            host.MarkupLine($"Using the agent [green]{current.Impl.Name}[/]:");
-            current.Display(host);
-        }
-        catch (Exception ex)
-        {
-            host.WriteErrorLine(ex.Message);
-        }
     }
 
     private void ConfigAgentAction(string name, string editor)

--- a/shell/AIShell.Kernel/Command/RefreshCommand.cs
+++ b/shell/AIShell.Kernel/Command/RefreshCommand.cs
@@ -17,8 +17,8 @@ internal sealed class RefreshCommand : CommandBase
         Console.SetCursorPosition(0, Console.WindowTop);
 
         var shell = (Shell)Shell;
-        shell.ActiveAgent.Impl.RefreshChat();
         shell.ShowBanner();
         shell.ShowLandingPage();
+        shell.ActiveAgent.Impl.RefreshChatAsync(Shell).GetAwaiter().GetResult();
     }
 }

--- a/shell/AIShell.Kernel/LLMAgent.cs
+++ b/shell/AIShell.Kernel/LLMAgent.cs
@@ -7,7 +7,6 @@ internal class LLMAgent
 {
     internal ILLMAgent Impl { get; }
     internal AgentAssemblyLoadContext LoadContext { get; }
-    internal bool OrchestratorRoleDisabled { set; get; }
     internal bool AnalyzerRoleDisabled { set; get; }
     internal string Prompt { set; get; }
 
@@ -16,7 +15,6 @@ internal class LLMAgent
         Impl = agent;
         LoadContext = loadContext;
 
-        OrchestratorRoleDisabled = false;
         AnalyzerRoleDisabled = false;
         Prompt = agent.Name;
     }
@@ -76,27 +74,5 @@ internal class LLMAgent
 
             host.WriteLine("\n");
         }
-    }
-
-    internal bool IsOrchestrator(out IOrchestrator orchestrator)
-    {
-        return Is(Impl, out orchestrator);
-    }
-
-    internal bool IsCodeAnalyzer(out ICodeAnalyzer analyzer)
-    {
-        return Is(Impl, out analyzer);
-    }
-
-    private static bool Is<T>(ILLMAgent obj, out T result) where T : ILLMAgent
-    {
-        if (obj is T value)
-        {
-            result = value;
-            return true;
-        }
-
-        result = default;
-        return false;
     }
 }

--- a/shell/AIShell.Kernel/LLMAgent.cs
+++ b/shell/AIShell.Kernel/LLMAgent.cs
@@ -7,15 +7,12 @@ internal class LLMAgent
 {
     internal ILLMAgent Impl { get; }
     internal AgentAssemblyLoadContext LoadContext { get; }
-    internal bool AnalyzerRoleDisabled { set; get; }
     internal string Prompt { set; get; }
 
     internal LLMAgent(ILLMAgent agent, AgentAssemblyLoadContext loadContext)
     {
         Impl = agent;
         LoadContext = loadContext;
-
-        AnalyzerRoleDisabled = false;
         Prompt = agent.Name;
     }
 

--- a/shell/AIShell.Kernel/Shell.cs
+++ b/shell/AIShell.Kernel/Shell.cs
@@ -294,7 +294,6 @@ internal sealed class Shell : IShell
             if (_isInteractive)
             {
                 ILLMAgent impl = chosenAgent.Impl;
-                CommandRunner.UnloadAgentCommands();
                 CommandRunner.LoadCommands(impl.GetCommands(), impl.Name);
             }
         }

--- a/shell/agents/AIShell.Azure.Agent/AzCLI/AzCLIAgent.cs
+++ b/shell/agents/AIShell.Azure.Agent/AzCLI/AzCLIAgent.cs
@@ -52,14 +52,6 @@ public sealed class AzCLIAgent : ILLMAgent
         SettingFile = Path.Combine(config.ConfigurationRoot, SettingFileName);
     }
 
-    public void RefreshChat()
-    {
-        // Reset the history so the subsequent chat can start fresh.
-        _chatService.ChatHistory.Clear();
-        ArgPlaceholder = null;
-        ValueStore.Clear();
-    }
-
     public IEnumerable<CommandBase> GetCommands() => [new ReplaceCommand(this)];
 
     public bool CanAcceptFeedback(UserAction action) => !MetricHelper.TelemetryOptOut;
@@ -109,7 +101,17 @@ public sealed class AzCLIAgent : ILLMAgent
             });
     }
 
-    public async Task<bool> Chat(string input, IShell shell)
+    public Task RefreshChatAsync(IShell shell)
+    {
+        // Reset the history so the subsequent chat can start fresh.
+        _chatService.ChatHistory.Clear();
+        ArgPlaceholder = null;
+        ValueStore.Clear();
+
+        return Task.CompletedTask;
+    }
+
+    public async Task<bool> ChatAsync(string input, IShell shell)
     {
         // Measure time spent
         _watch.Restart();

--- a/shell/agents/AIShell.Azure.Agent/AzPS/AzPSAgent.cs
+++ b/shell/agents/AIShell.Azure.Agent/AzPS/AzPSAgent.cs
@@ -56,12 +56,6 @@ public sealed class AzPSAgent : ILLMAgent
         _chatService = new AzPSChatService(config.IsInteractive, tenantId);
     }
 
-    public void RefreshChat()
-    {
-        // Reset the history so the subsequent chat can start fresh.
-        _chatService.ChatHistory.Clear();
-    }
-
     public IEnumerable<CommandBase> GetCommands() => null;
 
     public bool CanAcceptFeedback(UserAction action) => !MetricHelper.TelemetryOptOut;
@@ -111,7 +105,15 @@ public sealed class AzPSAgent : ILLMAgent
             });
     }
 
-    public async Task<bool> Chat(string input, IShell shell)
+    public Task RefreshChatAsync(IShell shell)
+    {
+        // Reset the history so the subsequent chat can start fresh.
+        _chatService.ChatHistory.Clear();
+
+        return Task.CompletedTask;
+    }
+
+    public async Task<bool> ChatAsync(string input, IShell shell)
     {
         // Measure time spent
         _watch.Restart();

--- a/shell/agents/AIShell.Interpreter.Agent/Agent.cs
+++ b/shell/agents/AIShell.Interpreter.Agent/Agent.cs
@@ -72,7 +72,7 @@ public sealed class InterpreterAgent : ILLMAgent
     }
 
     /// <inheritdoc/>
-    public void RefreshChat()
+    public Task RefreshChatAsync(IShell shell)
     {
         // Reload the setting file if needed.
         ReloadSettings();
@@ -80,6 +80,8 @@ public sealed class InterpreterAgent : ILLMAgent
         _chatService.RefreshChat();
         // Shut down the execution service to start fresh.
         _executionService.Terminate();
+
+        return Task.CompletedTask;
     }
 
     /// <inheritdoc/>
@@ -92,7 +94,7 @@ public sealed class InterpreterAgent : ILLMAgent
     public IEnumerable<CommandBase> GetCommands() => null;
 
     /// <inheritdoc/>
-    public async Task<bool> Chat(string input, IShell shell)
+    public async Task<bool> ChatAsync(string input, IShell shell)
     {
         IHost host = shell.Host;
         CancellationToken token = shell.CancellationToken;

--- a/shell/agents/AIShell.Ollama.Agent/OllamaAgent.cs
+++ b/shell/agents/AIShell.Ollama.Agent/OllamaAgent.cs
@@ -71,12 +71,6 @@ public sealed class OllamaAgent : ILLMAgent
     public string SettingFile { private set; get; } = null;
 
     /// <summary>
-    /// Refresh the current chat by starting a new chat session.
-    /// An agent can reset chat states in this method.
-    /// </summary>
-    public void RefreshChat() {}
-
-    /// <summary>
     /// Gets a value indicating whether the agent accepts a specific user action feedback.
     /// </summary>
     /// <param name="action">The user action.</param>
@@ -90,12 +84,18 @@ public sealed class OllamaAgent : ILLMAgent
     public void OnUserAction(UserActionPayload actionPayload) {}
 
     /// <summary>
+    /// Refresh the current chat by starting a new chat session.
+    /// This method allows an agent to reset chat states, interact with user for authentication, print welcome message, and more.
+    /// </summary>
+    public Task RefreshChatAsync(IShell shell) => Task.CompletedTask;
+
+    /// <summary>
     /// Main chat function that takes the users input and passes it to the LLM and renders it.
     /// </summary>
     /// <param name="input">The user input from the chat experience.</param>
     /// <param name="shell">The shell that provides host functionality.</param>
     /// <returns>Task Boolean that indicates whether the query was served by the agent.</returns>
-    public async Task<bool> Chat(string input, IShell shell)
+    public async Task<bool> ChatAsync(string input, IShell shell)
     {
         // Get the shell host
         IHost host = shell.Host;

--- a/shell/agents/AIShell.OpenAI.Agent/Agent.cs
+++ b/shell/agents/AIShell.OpenAI.Agent/Agent.cs
@@ -67,14 +67,6 @@ public sealed class OpenAIAgent : ILLMAgent
         _watcher.Changed += OnSettingFileChange;
     }
 
-    public void RefreshChat()
-    {
-        // Reload the setting file if needed.
-        ReloadSettings();
-        // Reset the history so the subsequent chat can start fresh.
-        _chatService.ChatHistory.Clear();
-    }
-
     /// <inheritdoc/>
     public IEnumerable<CommandBase> GetCommands() => [new GPTCommand(this)];
 
@@ -85,7 +77,18 @@ public sealed class OpenAIAgent : ILLMAgent
     public void OnUserAction(UserActionPayload actionPayload) {}
 
     /// <inheritdoc/>
-    public async Task<bool> Chat(string input, IShell shell)
+    public Task RefreshChatAsync(IShell shell)
+    {
+        // Reload the setting file if needed.
+        ReloadSettings();
+        // Reset the history so the subsequent chat can start fresh.
+        _chatService.ChatHistory.Clear();
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc/>
+    public async Task<bool> ChatAsync(string input, IShell shell)
     {
         IHost host = shell.Host;
         CancellationToken token = shell.CancellationToken;

--- a/shell/shell.common.props
+++ b/shell/shell.common.props
@@ -8,7 +8,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>12.0</LangVersion>
-    <Version>0.1.0-alpha.12</Version>
+    <Version>0.1.0-alpha.15</Version>
 
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

The orchestrator approach I tried with those interfaces doesn't really orchestrate across agents, and it requires the user to run `/agent pop` to return to the orchestrator after done with an agent selected by the orchestrator. That just won't work.

If we're ever going to support an orchestrator, it should be something like the Azure Orchestrator, where the user only talk to the orchestrator without needing to know what is happening behind the orchestrator.

- This PR removes those interfaces and the related experimenting code, so as to make it easier to refactor the code base for new feature request.
- The `void RefreshChat()` method is changed to an async method `Task RefreshChatAsync(IShell shell)`. This will be the place where an agent reset chat states, interact with user for authentication, print welcome message, and so on so forth.
- The call to `RefreshChatAsync` is moved to within the REPL, so exception thrown from the method can be handled (although it's best practice for the implementation of this method to not throw).