### PR TITLE
Minor fix to the calls of 'WriteErrorLine'

### DIFF
--- a/shell/AIShell.Kernel/Shell.cs
+++ b/shell/AIShell.Kernel/Shell.cs
@@ -639,12 +639,16 @@ internal sealed class Shell : IShell
                         continue;
                     }
 
-                    Host.WriteErrorLine($"\nAgent failed to generate a response: {ex.Message}\n{ex.StackTrace}\n");
+                    Host.WriteErrorLine()
+                        .WriteErrorLine($"Agent failed to generate a response: {ex.Message}\n{ex.StackTrace}")
+                        .WriteErrorLine();
                 }
             }
             catch (Exception e)
             {
-                Host.WriteErrorLine($"\n{e.Message}\n");
+                Host.WriteErrorLine()
+                    .WriteErrorLine($"{e.Message}\n{e.StackTrace}")
+                    .WriteErrorLine();
             }
         }
     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Minor fix to the calls of 'WriteErrorLine'. Given that `WriteErrorLine(string)` will prepend the error message with the prefix `Error: `, we should not add `\n` in the beginning of the error message.