### PR TITLE
Initial check-in for the new `azure` agent that talks to the Azure Orchestrator

### DIFF
--- a/build.psm1
+++ b/build.psm1
@@ -20,7 +20,7 @@ function Start-Build
         [string] $Runtime = [NullString]::Value,
 
         [Parameter()]
-        [ValidateSet('openai-gpt', 'az-agent', 'interpreter', 'ollama')]
+        [ValidateSet('openai-gpt', 'az-agent', 'ms-az', 'interpreter', 'ollama')]
         [string[]] $AgentToInclude,
 
         [Parameter()]
@@ -40,7 +40,7 @@ function Start-Build
     if (-not $AgentToInclude) {
         $agents = $metadata.AgentsToInclude
         $AgentToInclude = if ($agents -eq "*") {
-            @('openai-gpt', 'az-agent', 'interpreter', 'ollama')
+            @('openai-gpt', 'az-agent', 'ms-az', 'interpreter', 'ollama')
         } else {
             $agents.Split(",", [System.StringSplitOptions]::TrimEntries)
             Write-Verbose "Include agents specified in Metadata.json"
@@ -64,6 +64,7 @@ function Start-Build
 
     $openai_agent_dir = Join-Path $agent_dir "AIShell.OpenAI.Agent"
     $az_agent_dir = Join-Path $agent_dir "AIShell.Azure.Agent"
+    $ms_az_dir = Join-Path $agent_dir "Microsoft.Azure.Agent"
     $interpreter_agent_dir = Join-Path $agent_dir "AIShell.Interpreter.Agent"
     $ollama_agent_dir = Join-Path $agent_dir "AIShell.Ollama.Agent"
 
@@ -75,6 +76,7 @@ function Start-Build
 
     $openai_out_dir = Join-Path $app_out_dir "agents" "AIShell.OpenAI.Agent"
     $az_out_dir = Join-Path $app_out_dir "agents" "AIShell.Azure.Agent"
+    $ms_az_out_dir = Join-Path $app_out_dir "agents" "Microsoft.Azure.Agent"
     $interpreter_out_dir = Join-Path $app_out_dir "agents" "AIShell.Interpreter.Agent"
     $ollama_out_dir =  Join-Path $app_out_dir "agents" "AIShell.Ollama.Agent"
 
@@ -96,9 +98,15 @@ function Start-Build
     }
 
     if ($LASTEXITCODE -eq 0 -and $AgentToInclude -contains 'az-agent') {
-        Write-Host "`n[Build the Azure agents ...]`n" -ForegroundColor Green
+        Write-Host "`n[Build the az-ps/cli agents ...]`n" -ForegroundColor Green
         $az_csproj = GetProjectFile $az_agent_dir
         dotnet publish $az_csproj -c $Configuration -o $az_out_dir
+    }
+
+    if ($LASTEXITCODE -eq 0 -and $AgentToInclude -contains 'ms-az') {
+        Write-Host "`n[Build the Azure agent ...]`n" -ForegroundColor Green
+        $ms_az_csproj = GetProjectFile $ms_az_dir
+        dotnet publish $ms_az_csproj -c $Configuration -o $ms_az_out_dir
     }
 
     if ($LASTEXITCODE -eq 0 -and $AgentToInclude -contains 'interpreter') {

--- a/shell/AIShell.Abstraction/IHost.cs
+++ b/shell/AIShell.Abstraction/IHost.cs
@@ -97,7 +97,8 @@ public interface IHost
     /// Render a divider with the passed-in text.
     /// </summary>
     /// <param name="text">A brief caption for the subsequent section.</param>
-    void RenderDivider(string text);
+    /// <param name="alignment">Alignment of the text.</param>
+    void RenderDivider(string text, DividerAlignment alignment);
 
     /// <summary>
     /// Run an asynchronouse task with a spinner on the console showing the task in progress.
@@ -222,6 +223,22 @@ public enum SpinnerKind
     /// It should be used in all other cases, such as loading data, etc.
     /// </summary>
     Processing,
+}
+
+/// <summary>
+/// Enum type for the text alignment within a divider.
+/// </summary>
+public enum DividerAlignment
+{
+    /// <summary>
+    /// Text for the divider is left aligned.
+    /// </summary>
+    Left,
+
+    /// <summary>
+    /// Text for the divider is right aligned.
+    /// </summary>
+    Right,
 }
 
 /// <summary>

--- a/shell/AIShell.Kernel/Host.cs
+++ b/shell/AIShell.Kernel/Host.cs
@@ -310,14 +310,19 @@ internal sealed class Host : IHost
     }
 
     /// <inheritdoc/>
-    public void RenderDivider(string text)
+    public void RenderDivider(string text, DividerAlignment alignment)
     {
         ArgumentException.ThrowIfNullOrEmpty(text);
         RequireStdoutOrStderr(operation: "render divider");
 
-        AnsiConsole.Write(new Rule($"[yellow]{text.EscapeMarkup()}[/]")
-            .RuleStyle("grey")
-            .LeftJustified());
+        if (!text.Contains("[/]"))
+        {
+            text = $"[yellow]{text.EscapeMarkup()}[/]";
+        }
+
+        Justify justify = alignment is DividerAlignment.Left ? Justify.Left : Justify.Right;
+        Rule rule = new Rule(text).RuleStyle("grey").Justify(justify);
+        AnsiConsole.Write(rule);
     }
 
     /// <inheritdoc/>

--- a/shell/agents/AIShell.Azure.Agent/AzCLI/Command.cs
+++ b/shell/agents/AIShell.Azure.Agent/AzCLI/Command.cs
@@ -67,7 +67,7 @@ internal sealed class ReplaceCommand : CommandBase
             ? $"all {items.Count} argument placeholders"
             : "the argument placeholder";
         host.WriteLine($"\nWe'll provide assistance in replacing {subText} and regenerating the result. You can press 'Enter' to skip to the next parameter or press 'Ctrl+c' to exit the assistance.\n");
-        host.RenderDivider("Input Values");
+        host.RenderDivider("Input Values", DividerAlignment.Left);
         host.WriteLine();
 
         try
@@ -151,11 +151,11 @@ internal sealed class ReplaceCommand : CommandBase
 
         if (_values.Count > 0)
         {
-            host.RenderDivider("Summary");
+            host.RenderDivider("Summary", DividerAlignment.Left);
             host.WriteLine("\nThe following placeholders will be replace:");
             host.RenderList(_values);
 
-            host.RenderDivider("Regenerate");
+            host.RenderDivider("Regenerate", DividerAlignment.Left);
             host.MarkupLine($"\nQuery: [teal]{ap.Query}[/]");
 
             try

--- a/shell/agents/Microsoft.Azure.Agent/AzureAgent.cs
+++ b/shell/agents/Microsoft.Azure.Agent/AzureAgent.cs
@@ -1,0 +1,96 @@
+﻿using AIShell.Abstraction;
+
+namespace Microsoft.Azure.Agent;
+
+public sealed class AzCLIAgent : ILLMAgent
+{
+    public string Name => "Azure";
+    public string Description => "This AI assistant can help generate Azure CLI and Azure PowerShell scripts or commands for managing Azure resources and end-to-end scenarios that involve multiple different Azure resources.";
+    public string Company => "Microsoft";
+    public List<string> SampleQueries => [
+        "Create a VM with a public IP address",
+        "How to create a web app?",
+        "Backup an Azure SQL database to a storage container"
+    ];
+    public Dictionary<string, string> LegalLinks { private set; get; } = null;
+    public string SettingFile { private set; get; } = null;
+
+    private const string SettingFileName = "az.agent.json";
+
+    private ChatSession _chatSession;
+    private int _turnsLeft;
+
+    public void Dispose()
+    {
+        _chatSession?.Dispose();
+    }
+
+    public void Initialize(AgentConfig config)
+    {
+        _chatSession = new ChatSession();
+        _turnsLeft = int.MaxValue;
+
+        LegalLinks = new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["Terms"] = "https://aka.ms/TermsofUseCopilot",
+            ["Privacy"] = "https://aka.ms/privacy",
+            ["FAQ"] = "https://aka.ms/CopilotforAzureClientToolsFAQ",
+            ["Transparency"] = "https://aka.ms/CopilotAzCLIPSTransparency",
+        };
+
+        SettingFile = Path.Combine(config.ConfigurationRoot, SettingFileName);
+    }
+
+    public void RefreshChat()
+    {
+        // Refresh the chat session.
+        _chatSession.Refresh(CancellationToken.None);
+    }
+
+    public IEnumerable<CommandBase> GetCommands() => null;
+    public bool CanAcceptFeedback(UserAction action) => false;
+    public void OnUserAction(UserActionPayload actionPayload) {}
+
+    public async Task<bool> Chat(string input, IShell shell)
+    {
+        IHost host = shell.Host;
+        CancellationToken token = shell.CancellationToken;
+
+        if (_turnsLeft is 0)
+        {
+            host.WriteLine(@"\nYou have reached the limit of this conversation. Please run '/refresh' to start a new chat session.\n");
+        }
+
+        try
+        {
+            CopilotResponse copilotResponse = await host.RunWithSpinnerAsync(
+                status: "Thinking ...",
+                func: async context => await _chatSession.GetChatResponseAsync(context, input, token)
+            ).ConfigureAwait(false);
+
+            if (copilotResponse is not null)
+            {
+                host.RenderFullResponse(copilotResponse.Text);
+
+                var conversationState = copilotResponse.ConversationState;
+                string color = conversationState.TurnNumber switch
+                {
+                    < 10 => "green",
+                    < 15 => "yellow",
+                    _ => "red",
+                };
+
+                _turnsLeft = conversationState.TurnLimit - conversationState.TurnNumber;
+                host.RenderDivider($"[{color}]{conversationState.TurnNumber} of {conversationState.TurnLimit} requests[/]");
+            }
+        }
+        catch (Exception ex) when (ex is TokenRequestException or ConnectionDroppedException)
+        {
+            host.WriteErrorLine(ex.Message);
+            host.WriteErrorLine("Please run '/refresh' to start a new chat session and try again.");
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/shell/agents/Microsoft.Azure.Agent/AzureAgent.cs
+++ b/shell/agents/Microsoft.Azure.Agent/AzureAgent.cs
@@ -43,21 +43,17 @@ public sealed class AzureAgent : ILLMAgent
         SettingFile = Path.Combine(config.ConfigurationRoot, SettingFileName);
     }
 
-    public void RefreshChat()
-    {
-        // Refresh the chat session.
-        string welcome = _chatSession.NewConversation(CancellationToken.None);
-        if (!string.IsNullOrEmpty(welcome))
-        {
-            Description = welcome;
-        }
-    }
-
     public IEnumerable<CommandBase> GetCommands() => null;
     public bool CanAcceptFeedback(UserAction action) => false;
     public void OnUserAction(UserActionPayload actionPayload) {}
 
-    public async Task<bool> Chat(string input, IShell shell)
+    public async Task RefreshChatAsync(IShell shell)
+    {
+        // Refresh the chat session.
+        await _chatSession.RefreshAsync(shell.Host, shell.CancellationToken);
+    }
+
+    public async Task<bool> ChatAsync(string input, IShell shell)
     {
         IHost host = shell.Host;
         CancellationToken token = shell.CancellationToken;
@@ -97,7 +93,7 @@ public sealed class AzureAgent : ILLMAgent
                         CopilotActivity activity = copilotResponse.ChunkReader.ReadChunk(token);
                         if (activity is null)
                         {
-                            prevActivity.ParseMetadata(out string[] suggestion, out ConversationState state);
+                            prevActivity.ExtractMetadata(out string[] suggestion, out ConversationState state);
                             copilotResponse.SuggestedUserResponses = suggestion;
                             copilotResponse.ConversationState = state;
                             break;

--- a/shell/agents/Microsoft.Azure.Agent/AzureAgent.cs
+++ b/shell/agents/Microsoft.Azure.Agent/AzureAgent.cs
@@ -31,7 +31,7 @@ public sealed class AzureAgent : ILLMAgent
         _chatSession = new ChatSession();
         _turnsLeft = int.MaxValue;
 
-        Description = "This AI assistant can help generate Azure CLI and Azure PowerShell scripts or commands for managing Azure resources and end-to-end scenarios that involve multiple different Azure resources.";
+        Description = "This AI assistant can generate Azure CLI and Azure PowerShell commands for managing Azure resources, answer questions, and provides information tailored to your specific Azure environment.";
         LegalLinks = new(StringComparer.OrdinalIgnoreCase)
         {
             ["Terms"] = "https://aka.ms/TermsofUseCopilot",

--- a/shell/agents/Microsoft.Azure.Agent/AzureCopilotReceiver.cs
+++ b/shell/agents/Microsoft.Azure.Agent/AzureCopilotReceiver.cs
@@ -1,0 +1,110 @@
+using System.Collections.Concurrent;
+using System.Net.WebSockets;
+using System.Text.Json;
+
+namespace Microsoft.Azure.Agent;
+
+internal class AzureCopilotReceiver : IDisposable
+{
+    private const int BufferSize = 4096;
+
+    private readonly byte[] _buffer;
+    private readonly ClientWebSocket _webSocket;
+    private readonly MemoryStream _memoryStream;
+    private readonly CancellationTokenSource _cancelMessageReceiving;
+    private readonly BlockingCollection<CopilotActivity> _activityQueue;
+
+    private AzureCopilotReceiver(ClientWebSocket webSocket)
+    {
+        _webSocket = webSocket;
+        _buffer = new byte[BufferSize];
+        _memoryStream = new MemoryStream();
+        _cancelMessageReceiving = new CancellationTokenSource();
+        _activityQueue = new BlockingCollection<CopilotActivity>();
+
+        Watermark = -1;
+    }
+
+    internal int Watermark { get; private set; }
+    internal BlockingCollection<CopilotActivity> ActivityQueue => _activityQueue;
+
+    internal static async Task<AzureCopilotReceiver> CreateAsync(string streamUrl)
+    {
+        var webSocket = new ClientWebSocket();
+        await webSocket.ConnectAsync(new Uri(streamUrl), CancellationToken.None);
+
+        var copilotReader = new AzureCopilotReceiver(webSocket);
+        _ = Task.Run(copilotReader.ProcessActivities);
+
+        return copilotReader;
+    }
+
+    private async Task ProcessActivities()
+    {
+        while (_webSocket.State is WebSocketState.Open)
+        {
+            string closingMessage = null;
+            WebSocketReceiveResult result = null;
+
+            try
+            {
+                result = await _webSocket.ReceiveAsync(_buffer, _cancelMessageReceiving.Token);
+                if (result.MessageType is WebSocketMessageType.Close)
+                {
+                    closingMessage = "Close message received";
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // TODO: log the cancellation of the message receiving thread.
+                // Close the web socket before the thread is going away.
+                closingMessage = "Client closing";
+            }
+
+            if (closingMessage is not null)
+            {
+                // TODO: log the closing request.
+                await _webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, closingMessage, CancellationToken.None);
+                break;
+            }
+
+            // Occasionally, the Direct Line service sends an empty message as a liveness ping.
+            // We simply ignore these messages.
+            if (result.Count is 0)
+            {
+                continue;
+            }
+
+            _memoryStream.Write(_buffer, 0, result.Count);
+
+            if (result.EndOfMessage)
+            {
+                _memoryStream.Position = 0;
+                var rawResponse =  JsonSerializer.Deserialize<RawResponse>(_memoryStream, Utils.JsonOptions);
+                _memoryStream.SetLength(0);
+
+                if (rawResponse.Watermark is not null)
+                {
+                    Watermark = int.Parse(rawResponse.Watermark);
+                }
+
+                foreach (CopilotActivity activity in rawResponse.Activities)
+                {
+                    if (activity.From.Id.StartsWith("copilot", StringComparison.OrdinalIgnoreCase))
+                    {
+                        _activityQueue.Add(activity);
+                    }
+                }
+            }
+        }
+
+        // TODO: log the current state of the web socket
+        // TODO: handle error state, such as 'aborted'
+    }
+
+    public void Dispose()
+    {
+        _webSocket.Dispose();
+        _cancelMessageReceiving.Cancel();
+    }
+}

--- a/shell/agents/Microsoft.Azure.Agent/AzureCopilotReceiver.cs
+++ b/shell/agents/Microsoft.Azure.Agent/AzureCopilotReceiver.cs
@@ -90,7 +90,7 @@ internal class AzureCopilotReceiver : IDisposable
 
                 foreach (CopilotActivity activity in rawResponse.Activities)
                 {
-                    if (activity.From.Id.StartsWith("copilot", StringComparison.OrdinalIgnoreCase))
+                    if (activity.IsFromCopilot)
                     {
                         _activityQueue.Add(activity);
                     }

--- a/shell/agents/Microsoft.Azure.Agent/ChatSession.cs
+++ b/shell/agents/Microsoft.Azure.Agent/ChatSession.cs
@@ -1,6 +1,5 @@
 using System.Globalization;
 using System.Net.Http.Headers;
-using System.Net.WebSockets;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
@@ -16,59 +15,103 @@ internal class ChatSession : IDisposable
     private const string REFRESH_TOKEN_URL = "https://directline.botframework.com/v3/directline/tokens/refresh";
     internal const string CONVERSATION_URL = "https://directline.botframework.com/v3/directline/conversations";
 
-    private bool _initialized;
     private string _token;
-    private string _conversationUrl;
     private string _streamUrl;
+    private string _conversationUrl;
     private DateTime _expireOn;
-    private ClientWebSocket _webSocket;
-    private Task _wsConnectionTask;
+    private AzureCopilotReceiver _copilotReceiver;
 
     private readonly HttpClient _httpClient;
+    private readonly Dictionary<string, object> _flights;
 
     internal ChatSession()
     {
         _httpClient = new HttpClient();
+
+        // Keys and values for flights are from the portal request.
+        _flights = new Dictionary<string, object>()
+        {
+            ["openAIModel"] = "gpt4optuc",
+            ["openAIEndpointName"] = "norwayeast,australiaeast,westus",
+            ["docsHandlerEndpoint"] = "learnDocs",
+            ["unifiedcopilotdebug"] = false,
+            ["unifiedcopilottest"] = false,
+            ["captureintent"] = "true",
+            ["capturereasoning"] = "true",
+            ["captureparameters"] = "true",
+            ["logconversationturn"] = true,
+            ["aacopilot"] = true,
+            ["corecopilotmanager"] = true,
+            ["copilotdirectlinetokennameobjectid"] = true,
+            ["disableserverhandlerids"] = "SupportAndTroubleshootBot",
+            ["allowcopilotpaneresize"] = true,
+            ["copilotmanageability"] = true,
+            ["gpt4tcsprompt"] = true,
+            ["copilotmanageabilityuimenu"] = true,
+            ["usenewchatinputcomponent"] = true, // not sure what this is for
+            ["getformstate"] = true,
+            ["notificationcopilotbuttonallerror"] = false,
+            ["chitchatprompt"] = true,
+            ["streamresponse"] = true,
+        };
     }
 
-    internal void Refresh(CancellationToken cancellationToken)
+    internal string NewConversation(CancellationToken cancellationToken)
     {
         try
         {
-            GenerateToken(cancellationToken);
-            NewChatSession(cancellationToken);
-
-            _initialized = true;
+            Reset();
+            GenerateTokenAsync(cancellationToken).Wait(CancellationToken.None);
+            return StartConversationAsync(cancellationToken).GetAwaiter().GetResult();
         }
-        catch
+        catch (Exception e)
         {
             Reset();
-            throw;
+            if (e is OperationCanceledException)
+            {
+                Console.WriteLine("Failed to start a conversation because it was cancelled.");
+                Console.WriteLine("Please run '/refresh' to start a new conversation.");
+            }
+            else
+            {
+                Console.WriteLine($"Failed to start a conversation due to the following error: {e.Message}");
+                Console.WriteLine(e.StackTrace);
+                Console.WriteLine("\nPlease try '/refresh' to start a new conversation.");
+            }
         }
+
+        return null;
     }
 
     private void Reset()
     {
         _token = null;
-        _conversationUrl = null;
         _streamUrl = null;
+        _conversationUrl = null;
         _expireOn = DateTime.MinValue;
-        _webSocket = null;
-        _wsConnectionTask = null;
-        _initialized = false;
+
+        _copilotReceiver?.Dispose();
+        _copilotReceiver = null;
     }
 
-    private void GenerateToken(CancellationToken cancellationToken)
+    private async Task GenerateTokenAsync(CancellationToken cancellationToken)
     {
+        string manualToken = Environment.GetEnvironmentVariable("DL_TOKEN");
+        if (!string.IsNullOrEmpty(manualToken))
+        {
+            _token = manualToken;
+            return;
+        }
+
         try
         {
             HttpRequestMessage request = new(HttpMethod.Post, DL_TOKEN_URL);
             request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", DL_SECRET);
 
-            HttpResponseMessage response = _httpClient.Send(request, cancellationToken);
+            HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
             response.EnsureSuccessStatusCode();
 
-            Stream content = response.Content.ReadAsStream(cancellationToken);
+            Stream content = await response.Content.ReadAsStreamAsync(cancellationToken);
             TokenPayload tpl = JsonSerializer.Deserialize<TokenPayload>(content, Utils.JsonOptions);
 
             _token = tpl.Token;
@@ -79,15 +122,15 @@ internal class ChatSession : IDisposable
         }
     }
 
-    private void NewChatSession(CancellationToken cancellationToken)
+    private async Task<string> StartConversationAsync(CancellationToken cancellationToken)
     {
         HttpRequestMessage request = new(HttpMethod.Post, CONVERSATION_URL);
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
 
-        HttpResponseMessage response = _httpClient.Send(request, cancellationToken);
+        HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
         response.EnsureSuccessStatusCode();
 
-        Stream content = response.Content.ReadAsStream(cancellationToken);
+        Stream content = await response.Content.ReadAsStreamAsync(cancellationToken);
         SessionPayload spl = JsonSerializer.Deserialize<SessionPayload>(content, Utils.JsonOptions);
 
         _token = spl.Token;
@@ -95,8 +138,15 @@ internal class ChatSession : IDisposable
         _streamUrl = spl.StreamUrl;
         _expireOn = DateTime.UtcNow.AddSeconds(spl.ExpiresIn);
 
-        _webSocket = new ClientWebSocket();
-        _wsConnectionTask = _webSocket.ConnectAsync(new Uri(spl.StreamUrl), cancellationToken);
+        _copilotReceiver = await AzureCopilotReceiver.CreateAsync(_streamUrl);
+        while (true)
+        {
+            CopilotActivity activity = _copilotReceiver.ActivityQueue.Take(cancellationToken);
+            if (activity.Type is "message" && _copilotReceiver.Watermark is 0)
+            {
+                return activity.Text;
+            }
+        }
     }
 
     private void RenewToken(CancellationToken cancellationToken)
@@ -137,14 +187,40 @@ internal class ChatSession : IDisposable
     {
         var requestData = new
         {
-            locale = CultureInfo.CurrentCulture.Name,
             type = "message",
-            from = new { id = "user" },  // TODO, get user information
-            text = input
+            locale = CultureInfo.CurrentCulture.Name,
+            from = new { id = "user" },  // TODO, create a uuid to represent the user.
+            text = input,
+            attachments = new object[] {
+                new {
+                    contentType = "application/json",
+                    name = "azurecopilot/clienthandlerdefinitions",
+                    content =  new {
+                        clientHandlers = Array.Empty<object>()
+                    }
+                },
+                new {
+                    contentType = "application/json",
+                    name = "azurecopilot/viewcontext",
+                    content = new {
+                        viewContext = new {
+                            view = new {},
+                            additionalDetails = "{\"allContext\":[],\"additionalDetailsString\":\"{}\"}",
+                            resourceDetails = new {}
+                        }
+                    }
+                },
+                new {
+                    contentType = "application/json",
+                    name = "azurecopilot/flights",
+                    content = new {
+                        flights = _flights
+                    }
+                }
+            },
         };
 
         var json = JsonSerializer.Serialize(requestData, Utils.JsonOptions);
-
         var content = new StringContent(json, Encoding.UTF8, "application/json");
         var request = new HttpRequestMessage(HttpMethod.Post, _conversationUrl) { Content = content };
 
@@ -152,104 +228,71 @@ internal class ChatSession : IDisposable
         return request;
     }
 
-    private async Task<List<CopilotActivity>> ReceiveActivitiesAsync(MemoryStream stream, byte[] buffer, CancellationToken cancellationToken)
+    private async Task<string> SendQueryToCopilot(string input, CancellationToken cancellationToken)
     {
-        await _wsConnectionTask;
-        stream.SetLength(0);
+        // Sending query to Azure Copilot.
+        HttpRequestMessage request = PrepareForChat(input);
+        HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
+        response.EnsureSuccessStatusCode();
 
-        while (_webSocket.State is WebSocketState.Open)
-        {
-            var result = await _webSocket.ReceiveAsync(buffer, cancellationToken);
-            if (result.MessageType is WebSocketMessageType.Close)
-            {
-                await _webSocket.CloseAsync(
-                    WebSocketCloseStatus.NormalClosure,
-                    "Close message received",
-                    CancellationToken.None);
-
-                Reset();
-                throw new ConnectionDroppedException("Connection to Azure Copilot was dropped unexpectedly.");
-            }
-
-            stream.Write(buffer, 0, result.Count);
-
-            if (result.EndOfMessage && stream.Length > 0)
-            {
-                using JsonDocument doc = JsonDocument.Parse(stream);
-                JsonElement element = doc.RootElement.GetProperty("activities");
-                return element.Deserialize<List<CopilotActivity>>(Utils.JsonOptions);
-            }
-        }
-
-        throw new ConnectionDroppedException($"Connection to Azure Copilot was dropped unexpectedly (WebSocket state: {_webSocket.State}).");
+        // Retrieve the activity id of this query.
+        Stream content = await response.Content.ReadAsStreamAsync(cancellationToken);
+        JsonObject contentObj = JsonNode.Parse(content).AsObject();
+        return contentObj["id"].ToString();
     }
 
-    internal async Task<CopilotResponse> GetChatResponseAsync(IStatusContext context, string input, CancellationToken cancellationToken)
+    internal async Task<CopilotResponse> GetChatResponseAsync(string input, IStatusContext context, CancellationToken cancellationToken)
     {
         try
         {
-            if (_initialized)
-            {
-                context?.Status("Refreshing Token ...");
-                RenewToken(cancellationToken);
-            }
-            else
-            {
-                context?.Status("Starting chat session ...");
-                Refresh(cancellationToken);
-            }
+            // context?.Status("Refreshing Token ...");
+            // RenewToken(cancellationToken);
 
             context?.Status("Generating ...");
-
-            // Sending query to Azure Copilot.
-            HttpRequestMessage request = PrepareForChat(input);
-            HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
-            response.EnsureSuccessStatusCode();
-
-            // Retrieve the activity id of this query.
-            Stream content = await response.Content.ReadAsStreamAsync(cancellationToken);
-            JsonObject contentObj = JsonNode.Parse(content).AsObject();
-            string activityId = contentObj["id"].ToString();
-
-            MemoryStream stream = new();
-            byte[] buffer = new byte[512];
+            string activityId = await SendQueryToCopilot(input, cancellationToken);
 
             while (true)
             {
-                List<CopilotActivity> activities = await ReceiveActivitiesAsync(stream, buffer, cancellationToken);
-                foreach (CopilotActivity activity in activities)
+                CopilotActivity activity = _copilotReceiver.ActivityQueue.Take(cancellationToken);
+
+                if (activity.ReplyToId != activityId)
                 {
-                    if (activity.Type is "typing")
-                    {
-                        context?.Status(activity.Text);
-                        continue;
-                    }
-
-                    if (activity.Type is "message"
-                        && activity.From.Id.StartsWith("copilot", StringComparison.OrdinalIgnoreCase)
-                        && activity.ReplyToId == activityId)
-                    {
-                        CopilotResponse copilotResponse = new() { Text = activity.Text, TopicName = activity.TopicName };
-                        foreach (JsonObject jObj in activity.Attachments)
-                        {
-                            string name = jObj["name"].ToString();
-                            if (name is CopilotActivity.SuggestedResponseName)
-                            {
-                                copilotResponse.SuggestedUserResponses = jObj["content"].Deserialize<string[]>(Utils.JsonOptions);
-                            }
-                            else if (name is CopilotActivity.ConversationStateName)
-                            {
-                                copilotResponse.ConversationState = jObj["content"].Deserialize<ConversationState>(Utils.JsonOptions);
-                            }
-                        }
-
-                        return copilotResponse;
-                    }
+                    // Ignore an activity if it's not a reply to the current activityId.
+                    // This may happen when user cancels a response and thus the response activities from copilot were not consumed.
+                    continue;
                 }
+
+                if (activity.Type is "typing")
+                {
+                    context?.Status(activity.Text);
+                    continue;
+                }
+
+                if (activity.Type is "message")
+                {
+                    CopilotResponse ret = activity.InputHint switch
+                    {
+                        "typing"         => new CopilotResponse(new ChunkReader(_copilotReceiver, activity), activity.TopicName),
+                        "acceptingInput" => new CopilotResponse(activity.Text, activity.TopicName),
+                        _ => throw CorruptDataException.Create($"The 'inputHint'")
+                    };
+
+                    if (ret.ChunkReader is null)
+                    {
+                        activity.ParseMetadata(out string[] suggestion, out ConversationState state);
+                        ret.SuggestedUserResponses = suggestion;
+                        ret.ConversationState = state;
+                    }
+
+                    return ret;
+                }
+
+                throw CorruptDataException.Create($"The 'type' is '{activity.Type}', but we only expect 'typing' and 'message' as we don't support any client handlers.");
             }
         }
         catch (OperationCanceledException)
         {
+            // TODO: we may need to notify azure copilot somehow about the cancellation.
             return null;
         }
     }
@@ -257,5 +300,6 @@ internal class ChatSession : IDisposable
     public void Dispose()
     {
         _httpClient.Dispose();
+        _copilotReceiver?.Dispose();
     }
 }

--- a/shell/agents/Microsoft.Azure.Agent/ChatSession.cs
+++ b/shell/agents/Microsoft.Azure.Agent/ChatSession.cs
@@ -1,0 +1,261 @@
+using System.Globalization;
+using System.Net.Http.Headers;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using AIShell.Abstraction;
+
+namespace Microsoft.Azure.Agent;
+
+internal class ChatSession : IDisposable
+{
+    // private string? DL_SECRET = Environment.GetEnvironmentVariable("DL_SECRET");
+    private const string DL_SECRET = "p01apw-4RCo.0Ck32zNZ6DduKt3Y6ZxOLd-9UBWyg6sr0v4tsTR_n24";
+    private const string DL_TOKEN_URL = "https://directline.botframework.com/v3/directline/tokens/generate";
+    private const string REFRESH_TOKEN_URL = "https://directline.botframework.com/v3/directline/tokens/refresh";
+    internal const string CONVERSATION_URL = "https://directline.botframework.com/v3/directline/conversations";
+
+    private bool _initialized;
+    private string _token;
+    private string _conversationUrl;
+    private string _streamUrl;
+    private DateTime _expireOn;
+    private ClientWebSocket _webSocket;
+    private Task _wsConnectionTask;
+
+    private readonly HttpClient _httpClient;
+
+    internal ChatSession()
+    {
+        _httpClient = new HttpClient();
+    }
+
+    internal void Refresh(CancellationToken cancellationToken)
+    {
+        try
+        {
+            GenerateToken(cancellationToken);
+            NewChatSession(cancellationToken);
+
+            _initialized = true;
+        }
+        catch
+        {
+            Reset();
+            throw;
+        }
+    }
+
+    private void Reset()
+    {
+        _token = null;
+        _conversationUrl = null;
+        _streamUrl = null;
+        _expireOn = DateTime.MinValue;
+        _webSocket = null;
+        _wsConnectionTask = null;
+        _initialized = false;
+    }
+
+    private void GenerateToken(CancellationToken cancellationToken)
+    {
+        try
+        {
+            HttpRequestMessage request = new(HttpMethod.Post, DL_TOKEN_URL);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", DL_SECRET);
+
+            HttpResponseMessage response = _httpClient.Send(request, cancellationToken);
+            response.EnsureSuccessStatusCode();
+
+            Stream content = response.Content.ReadAsStream(cancellationToken);
+            TokenPayload tpl = JsonSerializer.Deserialize<TokenPayload>(content, Utils.JsonOptions);
+
+            _token = tpl.Token;
+        }
+        catch (Exception e) when (e is not OperationCanceledException)
+        {
+            throw new TokenRequestException($"Failed to generate the 'DirectLine' token: {e.Message}.", e);
+        }
+    }
+
+    private void NewChatSession(CancellationToken cancellationToken)
+    {
+        HttpRequestMessage request = new(HttpMethod.Post, CONVERSATION_URL);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
+
+        HttpResponseMessage response = _httpClient.Send(request, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        Stream content = response.Content.ReadAsStream(cancellationToken);
+        SessionPayload spl = JsonSerializer.Deserialize<SessionPayload>(content, Utils.JsonOptions);
+
+        _token = spl.Token;
+        _conversationUrl = $"{CONVERSATION_URL}/{spl.ConversationId}/activities";
+        _streamUrl = spl.StreamUrl;
+        _expireOn = DateTime.UtcNow.AddSeconds(spl.ExpiresIn);
+
+        _webSocket = new ClientWebSocket();
+        _wsConnectionTask = _webSocket.ConnectAsync(new Uri(spl.StreamUrl), cancellationToken);
+    }
+
+    private void RenewToken(CancellationToken cancellationToken)
+    {
+        var now = DateTime.UtcNow;
+        if (now > _expireOn || now.AddMinutes(2) >= _expireOn)
+        {
+            Reset();
+            throw new TokenRequestException("The chat session has expired. Please start a new chat session.");
+        }
+        else if (now.AddMinutes(10) < _expireOn)
+        {
+            return;
+        }
+
+        try
+        {
+            HttpRequestMessage request = new(HttpMethod.Post, REFRESH_TOKEN_URL);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
+
+            var response = _httpClient.Send(request, cancellationToken);
+            response.EnsureSuccessStatusCode();
+
+            Stream content = response.Content.ReadAsStream(cancellationToken);
+            TokenPayload tpl = JsonSerializer.Deserialize<TokenPayload>(content, Utils.JsonOptions);
+
+            _token = tpl.Token;
+            _expireOn = DateTime.UtcNow.AddSeconds(tpl.ExpiresIn);
+        }
+        catch (Exception e) when (e is not OperationCanceledException)
+        {
+            Reset();
+            throw new TokenRequestException($"Failed to refresh the 'DirectLine' token: {e.Message}.", e);
+        }
+    }
+
+    private HttpRequestMessage PrepareForChat(string input)
+    {
+        var requestData = new
+        {
+            locale = CultureInfo.CurrentCulture.Name,
+            type = "message",
+            from = new { id = "user" },  // TODO, get user information
+            text = input
+        };
+
+        var json = JsonSerializer.Serialize(requestData, Utils.JsonOptions);
+
+        var content = new StringContent(json, Encoding.UTF8, "application/json");
+        var request = new HttpRequestMessage(HttpMethod.Post, _conversationUrl) { Content = content };
+
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
+        return request;
+    }
+
+    private async Task<List<CopilotActivity>> ReceiveActivitiesAsync(MemoryStream stream, byte[] buffer, CancellationToken cancellationToken)
+    {
+        await _wsConnectionTask;
+        stream.SetLength(0);
+
+        while (_webSocket.State is WebSocketState.Open)
+        {
+            var result = await _webSocket.ReceiveAsync(buffer, cancellationToken);
+            if (result.MessageType is WebSocketMessageType.Close)
+            {
+                await _webSocket.CloseAsync(
+                    WebSocketCloseStatus.NormalClosure,
+                    "Close message received",
+                    CancellationToken.None);
+
+                Reset();
+                throw new ConnectionDroppedException("Connection to Azure Copilot was dropped unexpectedly.");
+            }
+
+            stream.Write(buffer, 0, result.Count);
+
+            if (result.EndOfMessage && stream.Length > 0)
+            {
+                using JsonDocument doc = JsonDocument.Parse(stream);
+                JsonElement element = doc.RootElement.GetProperty("activities");
+                return element.Deserialize<List<CopilotActivity>>(Utils.JsonOptions);
+            }
+        }
+
+        throw new ConnectionDroppedException($"Connection to Azure Copilot was dropped unexpectedly (WebSocket state: {_webSocket.State}).");
+    }
+
+    internal async Task<CopilotResponse> GetChatResponseAsync(IStatusContext context, string input, CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (_initialized)
+            {
+                context?.Status("Refreshing Token ...");
+                RenewToken(cancellationToken);
+            }
+            else
+            {
+                context?.Status("Starting chat session ...");
+                Refresh(cancellationToken);
+            }
+
+            context?.Status("Generating ...");
+
+            // Sending query to Azure Copilot.
+            HttpRequestMessage request = PrepareForChat(input);
+            HttpResponseMessage response = await _httpClient.SendAsync(request, cancellationToken);
+            response.EnsureSuccessStatusCode();
+
+            // Retrieve the activity id of this query.
+            Stream content = await response.Content.ReadAsStreamAsync(cancellationToken);
+            JsonObject contentObj = JsonNode.Parse(content).AsObject();
+            string activityId = contentObj["id"].ToString();
+
+            MemoryStream stream = new();
+            byte[] buffer = new byte[512];
+
+            while (true)
+            {
+                List<CopilotActivity> activities = await ReceiveActivitiesAsync(stream, buffer, cancellationToken);
+                foreach (CopilotActivity activity in activities)
+                {
+                    if (activity.Type is "typing")
+                    {
+                        context?.Status(activity.Text);
+                        continue;
+                    }
+
+                    if (activity.Type is "message"
+                        && activity.From.Id.StartsWith("copilot", StringComparison.OrdinalIgnoreCase)
+                        && activity.ReplyToId == activityId)
+                    {
+                        CopilotResponse copilotResponse = new() { Text = activity.Text, TopicName = activity.TopicName };
+                        foreach (JsonObject jObj in activity.Attachments)
+                        {
+                            string name = jObj["name"].ToString();
+                            if (name is CopilotActivity.SuggestedResponseName)
+                            {
+                                copilotResponse.SuggestedUserResponses = jObj["content"].Deserialize<string[]>(Utils.JsonOptions);
+                            }
+                            else if (name is CopilotActivity.ConversationStateName)
+                            {
+                                copilotResponse.ConversationState = jObj["content"].Deserialize<ConversationState>(Utils.JsonOptions);
+                            }
+                        }
+
+                        return copilotResponse;
+                    }
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            return null;
+        }
+    }
+
+    public void Dispose()
+    {
+        _httpClient.Dispose();
+    }
+}

--- a/shell/agents/Microsoft.Azure.Agent/Microsoft.Azure.Agent.csproj
+++ b/shell/agents/Microsoft.Azure.Agent/Microsoft.Azure.Agent.csproj
@@ -17,7 +17,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.11.4" />
-    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.18.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/shell/agents/Microsoft.Azure.Agent/Microsoft.Azure.Agent.csproj
+++ b/shell/agents/Microsoft.Azure.Agent/Microsoft.Azure.Agent.csproj
@@ -1,0 +1,32 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
+
+    <!-- Disable deps.json generation -->
+    <GenerateDependencyFile>false</GenerateDependencyFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <!-- Disable PDB generation for the Release build -->
+    <DebugSymbols>false</DebugSymbols>
+    <DebugType>None</DebugType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Identity" Version="1.11.4" />
+    <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.18.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\AIShell.Abstraction\AIShell.Abstraction.csproj">
+      <!-- Disable copying AIShell.Abstraction.dll to output folder -->
+      <Private>false</Private>
+      <!-- Disable copying the transitive dependencies to output folder -->
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </ProjectReference>
+  </ItemGroup>
+
+</Project>

--- a/shell/agents/Microsoft.Azure.Agent/Schema.cs
+++ b/shell/agents/Microsoft.Azure.Agent/Schema.cs
@@ -1,0 +1,75 @@
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using Microsoft.Identity.Client;
+
+namespace Microsoft.Azure.Agent;
+
+internal class TokenPayload
+{
+    public string ConversationId { get; set; }
+    public string Token { get; set; }
+
+    [JsonPropertyName("expires_in")]
+    public int ExpiresIn { get; set; }
+}
+
+internal class SessionPayload
+{
+    public string ConversationId { get; set; }
+    public string Token { get; set; }
+
+    [JsonPropertyName("expires_in")]
+    public int ExpiresIn { get; set; }
+
+    public string StreamUrl { get; set; }
+    public string ReferenceGrammarId { get; set; }
+}
+
+/// <summary>
+/// Interface for copilot channel account.
+/// </summary>
+internal class ChannelAccount
+{
+    public string Id { get; set; }
+    public string Name { get; set; }
+};
+
+/// <summary>
+/// Interface for copilot activity data.
+/// </summary>
+internal class CopilotActivity
+{
+    public const string ConversationStateName = "azurecopilot/conversationstate";
+    public const string SuggestedResponseName = "azurecopilot/suggesteduserresponses";
+
+    public string Type { get; set; }
+    public string Id { get; set; }
+    public string Timestamp { get; set; }
+    public string ChannelId { get; set; }
+    public ChannelAccount From { get; set; }
+    public string TopicName { get; set; }
+    public string Text { get; set; }
+    public string InputHint { get; set; }
+    public JsonObject[] Attachments { get; set; }
+    public string ReplyToId { get; set; }
+};
+
+internal class ConversationState
+{
+    public int TurnLimit { get; set; }
+    public int TurnNumber { get; set; }
+    public bool TurnLimitMet { get; set; }
+    public bool TurnLimitExceeded { get; set; }
+
+    public int DailyConversationNumber { get; set; }
+    public bool DailyConversationLimitMet { get; set; }
+    public bool DailyConversationLimitExceeded { get; set; }
+}
+
+internal class CopilotResponse
+{
+    public string Text { get; set; }
+    public string TopicName { get; set; }
+    public string[] SuggestedUserResponses { get; set; }
+    public ConversationState ConversationState { get; set; }
+}

--- a/shell/agents/Microsoft.Azure.Agent/Schema.cs
+++ b/shell/agents/Microsoft.Azure.Agent/Schema.cs
@@ -54,9 +54,14 @@ internal class CopilotActivity
     public string ReplyToId { get; set; }
 
     internal Exception Error { get; set; }
-    internal void ParseMetadata(
-        out string[] suggestedUserResponses,
-        out ConversationState conversationState)
+
+    internal bool IsFromCopilot => From.Id.StartsWith("copilot", StringComparison.OrdinalIgnoreCase);
+    internal bool IsTyping => Type is "typing";
+    internal bool IsEvent => Type is "event";
+    internal bool IsMessage => Type is "message";
+    internal bool IsMessageUpdate => Type is "messageUpdate";
+
+    internal void ExtractMetadata(out string[] suggestedUserResponses, out ConversationState conversationState)
     {
         suggestedUserResponses = null;
         conversationState = null;
@@ -154,7 +159,7 @@ internal class ChunkReader
 
         CopilotActivity activity = _receiver.ActivityQueue.Take(cancellationToken);
 
-        if (activity.Type is not "messageUpdate")
+        if (!activity.IsMessageUpdate)
         {
             throw CorruptDataException.Create($"The 'type' should be 'messageUpdate' but it's '{activity.Type}'.");
         }

--- a/shell/agents/Microsoft.Azure.Agent/Utils.cs
+++ b/shell/agents/Microsoft.Azure.Agent/Utils.cs
@@ -1,0 +1,51 @@
+using System.Text.Json;
+
+namespace Microsoft.Azure.Agent;
+
+internal static class Utils
+{
+    private static readonly JsonSerializerOptions s_jsonOptions;
+
+    static Utils()
+    {
+        s_jsonOptions = new JsonSerializerOptions()
+        {
+            WriteIndented = false,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        };
+    }
+
+    internal static JsonSerializerOptions JsonOptions => s_jsonOptions;
+
+    /// <summary>
+    /// Keep 3 conversation iterations as the context information.
+    /// </summary>
+    internal const int HistoryCount = 6;
+}
+
+internal class TokenRequestException : Exception
+{
+    internal TokenRequestException(string message)
+        : base(message)
+    {
+    }
+
+    internal TokenRequestException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+}
+
+internal class ConnectionDroppedException : Exception
+{
+    internal ConnectionDroppedException(string message)
+        : base(message)
+    {
+    }
+}
+
+internal class ChatMessage
+{
+    public string Role { get; set; }
+    public string Content { get; set; }
+}

--- a/shell/agents/Microsoft.Azure.Agent/Utils.cs
+++ b/shell/agents/Microsoft.Azure.Agent/Utils.cs
@@ -44,6 +44,19 @@ internal class ConnectionDroppedException : Exception
     }
 }
 
+internal class CorruptDataException : Exception
+{
+    internal CorruptDataException(string message)
+        : base(message)
+    {
+    }
+
+    internal static CorruptDataException Create(string message)
+    {
+        return new CorruptDataException($"Unexpected copilot activity received. {message}");
+    }
+}
+
 internal class ChatMessage
 {
     public string Role { get; set; }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Initial check-in for the new `azure` agent that talks to the Azure Orchestrator.

- Add the initial work of the new agent, which talks to Azure Copilot with token grabbed from Azure Portal manually.
- Wrap the client web socket into a data structure that allows us to easily consume both streaming and non-streaming output.
- Get it ready to support authentication in a more streamline way in `RefreshChatAsync`.
