### PR TITLE
Enforce KS3 for Linux agent and also use PSResourceGet command for creating `nupkg` for the `AIShell` module

### DIFF
--- a/.pipelines/Build-Official.yml
+++ b/.pipelines/Build-Official.yml
@@ -9,11 +9,6 @@ parameters:
 
 resources:
   repositories:
-  - repository: ComplianceRepo
-    type: github
-    endpoint: ComplianceGHRepo
-    name: PowerShell/compliance
-    ref: master
   - repository: onebranchTemplates
     type: git
     name: OneBranch.Pipelines/GovernedTemplates
@@ -39,7 +34,7 @@ variables:
   - name: LinuxContainerImage
     value: mcr.microsoft.com/onebranch/cbl-mariner/build:2.0
   - name: WindowsContainerImage
-    value: onebranch.azurecr.io/windows/ltsc2019/vse2022:latest
+    value: onebranch.azurecr.io/windows/ltsc2022/vse2022:latest
   - name: CDP_DEFINITION_BUILD_COUNT
     value: $[counter('', 0)]
   - name: SKIP_SIGNING
@@ -53,9 +48,10 @@ extends:
     customTags: 'ES365AIMigrationTooling'
     featureFlags:
       LinuxHostVersion:
-          Network: KS3
+        Network: KS3
       WindowsHostVersion:
-          Network: KS3
+        Version: 2022
+        Network: KS3
     globalSdl:
       disableLegacyManifest: true
       # disabled Armorty as we dont have any ARM templates to scan. It fails on some sample ARM templates.

--- a/.pipelines/Package-Official.yml
+++ b/.pipelines/Package-Official.yml
@@ -35,7 +35,7 @@ variables:
   - name: ob_outputDirectory
     value: '$(Build.ArtifactStagingDirectory)/ONEBRANCH_ARTIFACT'
   - name: WindowsContainerImage
-    value: 'onebranch.azurecr.io/windows/ltsc2019/vse2022:latest' # Docker image which is used to build the project
+    value: 'onebranch.azurecr.io/windows/ltsc2022/vse2022:latest' # Docker image which is used to build the project
   - name: LinuxContainerImage
     value: mcr.microsoft.com/onebranch/cbl-mariner/build:2.0
   - group: mscodehub-feed-read-general
@@ -69,6 +69,11 @@ extends:
       enabled: false
     featureFlags:
       linuxEsrpSigning: true
+      LinuxHostVersion:
+        Network: KS3
+      WindowsHostVersion:
+        Version: 2022
+        Network: KS3
     globalSdl:
       disableLegacyManifest: true
       # disabled Armorty as we dont have any ARM templates to scan. It fails on some sample ARM templates.

--- a/.pipelines/Package-Official.yml
+++ b/.pipelines/Package-Official.yml
@@ -73,7 +73,6 @@ extends:
         Network: KS3
       WindowsHostVersion:
         Version: 2022
-        Network: KS3
     globalSdl:
       disableLegacyManifest: true
       # disabled Armorty as we dont have any ARM templates to scan. It fails on some sample ARM templates.

--- a/.pipelines/templates/check-Azure-container.yml
+++ b/.pipelines/templates/check-Azure-container.yml
@@ -63,7 +63,6 @@ jobs:
       inline: |
         Write-Verbose -Verbose 'Create storage context for $(PSInfraStorageAccount)'
         $context = New-AzStorageContext -StorageAccountName '$(PSInfraStorageAccount)' -UseConnectedAccount
-        Write-Verbose -Verbose 'Storage context created'
         $containersToDelete = @{
           '$web' = 'aish/$(PackageVersion)'
           'aish' = '$(PackageVersion)'
@@ -75,7 +74,7 @@ jobs:
             $blobPrefix = $entry.Value
             $virtualContainer = "$container/$blobPrefix"
 
-            Write-Verbose -Verbose "Operate on virtual container $virtualContainer"
+            Write-Verbose -Verbose "Operate on virtual container $virtualContainer ..."
             $blobs = Get-AzStorageBlob -Container $container -Context $context | Where-Object Name -Like "$blobPrefix/*" -ErrorAction Stop
             if ($null -ne $blobs) {
               if ('$(ForceAzureBlobDelete)' -eq 'true') {

--- a/.pipelines/templates/check-Azure-container.yml
+++ b/.pipelines/templates/check-Azure-container.yml
@@ -63,6 +63,7 @@ jobs:
       inline: |
         Write-Verbose -Verbose 'Create storage context for $(PSInfraStorageAccount)'
         $context = New-AzStorageContext -StorageAccountName '$(PSInfraStorageAccount)' -UseConnectedAccount
+        Write-Verbose -Verbose 'Storage context created'
         $containersToDelete = @{
           '$web' = 'aish/$(PackageVersion)'
           'aish' = '$(PackageVersion)'
@@ -74,6 +75,7 @@ jobs:
             $blobPrefix = $entry.Value
             $virtualContainer = "$container/$blobPrefix"
 
+            Write-Verbose -Verbose "Operate on virtual container $virtualContainer"
             $blobs = Get-AzStorageBlob -Container $container -Context $context | Where-Object Name -Like "$blobPrefix/*" -ErrorAction Stop
             if ($null -ne $blobs) {
               if ('$(ForceAzureBlobDelete)' -eq 'true') {

--- a/.pipelines/templates/module-package.yml
+++ b/.pipelines/templates/module-package.yml
@@ -80,7 +80,7 @@ jobs:
         Register-PSResourceRepository -Name $RepoName -Uri $nugetPath -Trusted
         Publish-PSResource -Repository $RepoName -Path $moduleFolder
       } finally {
-        Unregister-PSResourceRepository -Name $RepoName -Force -ErrorAction SilentlyContinue
+        Unregister-PSResourceRepository -Name $RepoName -ErrorAction SilentlyContinue
       }
       Get-ChildItem -Path $nugetPath | Out-String -Width 500 -Stream
     displayName: 'Create the NuGet package'

--- a/.pipelines/templates/module-package.yml
+++ b/.pipelines/templates/module-package.yml
@@ -77,10 +77,10 @@ jobs:
 
       try {
         $RepoName = "PSRLLocal"
-        Register-PSRepository -Name $RepoName -SourceLocation $nugetPath -PublishLocation $nugetPath -InstallationPolicy Trusted
-        Publish-Module -Repository $RepoName -Path $moduleFolder
+        Register-PSResourceRepository -Name $RepoName -Uri $nugetPath -Trusted
+        Publish-PSResource -Repository $RepoName -Path $moduleFolder
       } finally {
-        Unregister-PSRepository -Name $RepoName -ErrorAction SilentlyContinue
+        Unregister-PSResourceRepository -Name $RepoName -Force -ErrorAction SilentlyContinue
       }
       Get-ChildItem -Path $nugetPath | Out-String -Width 500 -Stream
     displayName: 'Create the NuGet package'


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

This PR is for resolve a CFS issue caused by `Register-PSResourceRepository` and `Publish-Module` from `PowerShellGet`. Those 2 cmdlets seem to talk to `nuget.org` even though we just want to register a local repository with a local folder path.

KS3 is not enforced for Windows in the packaging pipeline because it would block operations on the Azure container/blobs using Azure PowerShell cmdlet. The operations will fail after 6 re-tries:

> ##[error]Retry failed after 6 tries. Retry settings can be adjusted in ClientOptions.Retry or by configuring a custom retry policy in ClientOptions.RetryPolicy.

Test OneBranch build: https://dev.azure.com/mscodehub/PowerShellCore/_build/results?buildId=532130&view=results