### PR TITLE
Handle errors that may happen in the web socket receiver thread

### DIFF
--- a/shell/agents/Microsoft.Azure.Agent/AzureCopilotReceiver.cs
+++ b/shell/agents/Microsoft.Azure.Agent/AzureCopilotReceiver.cs
@@ -41,6 +41,7 @@ internal class AzureCopilotReceiver : IDisposable
 
     private async Task ProcessActivities()
     {
+        Exception error;
         while (_webSocket.State is WebSocketState.Open)
         {
             string closingMessage = null;
@@ -52,7 +53,8 @@ internal class AzureCopilotReceiver : IDisposable
                 if (result.MessageType is WebSocketMessageType.Close)
                 {
                     closingMessage = "Close message received";
-                    _activityQueue.Add(new CopilotActivity { Error = new ConnectionDroppedException("The server websocket is closing. Connection dropped.") });
+                    error = new("The server websocket is closing. Connection dropped.");
+                    _activityQueue.Add(new CopilotActivity { Error = error });
                 }
             }
             catch (OperationCanceledException)
@@ -101,7 +103,8 @@ internal class AzureCopilotReceiver : IDisposable
         }
 
         // TODO: log the current state of the web socket.
-        _activityQueue.Add(new CopilotActivity { Error = new ConnectionDroppedException($"State of the websocket is '{_webSocket.State}'. Connection dropped.") });
+        error = new($"The websocket got in '{_webSocket.State}' state. Connection dropped.");
+        _activityQueue.Add(new CopilotActivity { Error = error });
         _activityQueue.CompleteAdding();
     }
 

--- a/shell/agents/Microsoft.Azure.Agent/AzureCopilotReceiver.cs
+++ b/shell/agents/Microsoft.Azure.Agent/AzureCopilotReceiver.cs
@@ -41,7 +41,6 @@ internal class AzureCopilotReceiver : IDisposable
 
     private async Task ProcessActivities()
     {
-        Exception error;
         while (_webSocket.State is WebSocketState.Open)
         {
             string closingMessage = null;
@@ -53,8 +52,7 @@ internal class AzureCopilotReceiver : IDisposable
                 if (result.MessageType is WebSocketMessageType.Close)
                 {
                     closingMessage = "Close message received";
-                    error = new("The server websocket is closing. Connection dropped.");
-                    _activityQueue.Add(new CopilotActivity { Error = error });
+                    _activityQueue.Add(new CopilotActivity { Error = new ConnectionDroppedException("The server websocket is closing. Connection dropped.") });
                 }
             }
             catch (OperationCanceledException)
@@ -103,8 +101,7 @@ internal class AzureCopilotReceiver : IDisposable
         }
 
         // TODO: log the current state of the web socket.
-        error = new($"The websocket got in '{_webSocket.State}' state. Connection dropped.");
-        _activityQueue.Add(new CopilotActivity { Error = error });
+        _activityQueue.Add(new CopilotActivity { Error = new ConnectionDroppedException($"The websocket got in '{_webSocket.State}' state. Connection dropped.") });
         _activityQueue.CompleteAdding();
     }
 

--- a/shell/agents/Microsoft.Azure.Agent/ChatSession.cs
+++ b/shell/agents/Microsoft.Azure.Agent/ChatSession.cs
@@ -142,7 +142,7 @@ internal class ChatSession : IDisposable
 
         while (true)
         {
-            CopilotActivity activity = _copilotReceiver.ActivityQueue.Take(cancellationToken);
+            CopilotActivity activity = _copilotReceiver.Take(cancellationToken);
             if (activity.IsMessage && activity.IsFromCopilot && _copilotReceiver.Watermark is 0)
             {
                 activity.ExtractMetadata(out _, out ConversationState conversationState);
@@ -259,7 +259,7 @@ internal class ChatSession : IDisposable
 
             while (true)
             {
-                CopilotActivity activity = _copilotReceiver.ActivityQueue.Take(cancellationToken);
+                CopilotActivity activity = _copilotReceiver.Take(cancellationToken);
 
                 if (activity.ReplyToId != activityId)
                 {

--- a/shell/agents/Microsoft.Azure.Agent/Schema.cs
+++ b/shell/agents/Microsoft.Azure.Agent/Schema.cs
@@ -159,7 +159,7 @@ internal class ChunkReader
             return null;
         }
 
-        CopilotActivity activity = _receiver.ActivityQueue.Take(cancellationToken);
+        CopilotActivity activity = _receiver.Take(cancellationToken);
 
         if (!activity.IsMessageUpdate)
         {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

When error happens in the web socket receiver thread, we create a `CopilotActivity` with the exception from the error, and pass add it to the collection. When the agent reads from the receiver, if the next activity's `Error` field is not null, then the error gets thrown out at the consumer side.