### PR TITLE
Update the footer that indicates the turns of a conversation according to the UI design

### DIFF
--- a/shell/agents/Microsoft.Azure.Agent/AzureAgent.cs
+++ b/shell/agents/Microsoft.Azure.Agent/AzureAgent.cs
@@ -112,15 +112,22 @@ public sealed class AzureAgent : ILLMAgent
             }
 
             var conversationState = copilotResponse.ConversationState;
-            string color = conversationState.TurnNumber switch
-            {
-                < 10 => "green",
-                < 15 => "yellow",
-                _ => "red",
-            };
-
             _turnsLeft = conversationState.TurnLimit - conversationState.TurnNumber;
-            host.RenderDivider($"[{color}]{conversationState.TurnNumber} of {conversationState.TurnLimit} requests[/]", DividerAlignment.Right);
+            if (_turnsLeft <= 5)
+            {
+                string message = _turnsLeft switch
+                {
+                    1 => $"[yellow]{_turnsLeft} request left[/]",
+                    0 => $"[red]{_turnsLeft} request left[/]",
+                    _ => $"[yellow]{_turnsLeft} requests left[/]",
+                };
+
+                host.RenderDivider(message, DividerAlignment.Right);
+                if (_turnsLeft is 0)
+                {
+                    host.WriteLine("\nYou've reached the maximum length of a conversation. To continue, please run '/refresh' to start a new conversation.\n");
+                }
+            }
         }
         catch (Exception ex) when (ex is TokenRequestException or ConnectionDroppedException)
         {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Update the footer that indicates the turns of a conversation according to the UI design.
Now, instead of showing the footer for every response, we start to show it when there are 5 or less requests left for the current conversation.

![image](https://github.com/user-attachments/assets/ad59b8ee-0a72-4cbd-ba28-9e4a80cf8f3b)
![image](https://github.com/user-attachments/assets/93e4549b-41fb-4ad6-bf68-3076d8624081)
