### PR TITLE
Invoke-AIShell: make the `-Query` parameter accept values from remaining arguments

### DIFF
--- a/shell/AIShell.Integration/Commands/InvokeAishCommand.cs
+++ b/shell/AIShell.Integration/Commands/InvokeAishCommand.cs
@@ -2,20 +2,20 @@ using System.Collections.ObjectModel;
 using System.Management.Automation;
 using AIShell.Abstraction;
 
-namespace AIShell.Integration;
+namespace AIShell.Integration.Commands;
 
 [Alias("askai")]
 [Cmdlet(VerbsLifecycle.Invoke, "AIShell", DefaultParameterSetName = "Default")]
 public class InvokeAIShellCommand : PSCmdlet
 {
-    [Parameter(Position = 0, Mandatory = true)]
-    public string Query { get; set; }
+    [Parameter(Mandatory = true, ValueFromRemainingArguments = true)]
+    public string[] Query { get; set; }
 
     [Parameter]
     [ValidateNotNullOrEmpty]
     public string Agent { get; set; }
 
-    [Parameter(ParameterSetName = "Default", Position = 1, Mandatory = false, ValueFromPipeline = true)]
+    [Parameter(ParameterSetName = "Default", Mandatory = false, ValueFromPipeline = true)]
     public PSObject Context { get; set; }
 
     [Parameter(ParameterSetName = "Clipboard", Mandatory = true)]
@@ -55,6 +55,6 @@ public class InvokeAIShellCommand : PSCmdlet
         }
 
         string context = results?.Count > 0 ? results[0] : null;
-        Channel.Singleton.PostQuery(new PostQueryMessage(Query, context, Agent));
+        Channel.Singleton.PostQuery(new PostQueryMessage(string.Join(' ', Query), context, Agent));
     }
 }

--- a/shell/AIShell.Integration/Commands/ResolveErrorCommand.cs
+++ b/shell/AIShell.Integration/Commands/ResolveErrorCommand.cs
@@ -3,7 +3,7 @@ using System.Management.Automation;
 using Microsoft.PowerShell.Commands;
 using AIShell.Abstraction;
 
-namespace AIShell.Integration;
+namespace AIShell.Integration.Commands;
 
 [Alias("fixit")]
 [Cmdlet(VerbsDiagnostic.Resolve, "Error")]

--- a/shell/AIShell.Integration/Commands/StartAishCommand.cs
+++ b/shell/AIShell.Integration/Commands/StartAishCommand.cs
@@ -2,7 +2,7 @@ using System.Diagnostics;
 using System.Management.Automation;
 using System.Text;
 
-namespace AIShell.Integration;
+namespace AIShell.Integration.Commands;
 
 [Alias("aish")]
 [Cmdlet(VerbsLifecycle.Start, "AIShell")]


### PR DESCRIPTION
### PR Summary

Make the `-Query` parameter accept values from remaining arguments, so that a user doesn't have to always enclose a query in quotes. Instead, one can run `Invoke-AIShell what are the different types of functions?`