### PR TITLE
Simplify parameter injection UI and fix a few bugs

### DIFF
--- a/shell/agents/Microsoft.Azure.Agent/AzureAgent.cs
+++ b/shell/agents/Microsoft.Azure.Agent/AzureAgent.cs
@@ -335,7 +335,10 @@ public sealed class AzureAgent : ILLMAgent
             {
                 string script = command.Script;
                 command.Script = script.Replace(entry.Key, entry.Value, StringComparison.OrdinalIgnoreCase);
-                command.Updated = !ReferenceEquals(script, command.Script);
+                if (!ReferenceEquals(script, command.Script))
+                {
+                    command.Updated = true;
+                }
             }
         }
 

--- a/shell/agents/Microsoft.Azure.Agent/ChatSession.cs
+++ b/shell/agents/Microsoft.Azure.Agent/ChatSession.cs
@@ -149,7 +149,7 @@ internal class ChatSession : IDisposable
                 int chatNumber = conversationState.DailyConversationNumber;
                 int requestNumber = conversationState.TurnNumber;
 
-                host.WriteLine($"\n{activity.Text} This is chat #{chatNumber}, request #{requestNumber}.\n");
+                host.WriteLine($"\n{activity.Text}\nThis is chat #{chatNumber}, request #{requestNumber}.\n");
                 return;
             }
         }

--- a/shell/agents/Microsoft.Azure.Agent/Command.cs
+++ b/shell/agents/Microsoft.Azure.Agent/Command.cs
@@ -61,7 +61,7 @@ internal sealed class ReplaceCommand : CommandBase
         string subText = items.Count > 1
             ? $"all {items.Count} argument placeholders"
             : "the argument placeholder";
-        host.WriteLine($"\nWe'll provide assistance in replacing {subText} and regenerating the result. You can press 'Enter' to skip to the next parameter or press 'Ctrl+c' to exit the assistance.\n");
+        host.WriteLine($"\nWe'll provide assistance in replacing {subText} and regenerating the result.\nYou can press 'Enter' to skip to the next parameter or press 'Ctrl+c' to exit the assistance.\n");
         host.RenderDivider("Input Values", DividerAlignment.Left);
         host.WriteLine();
 

--- a/shell/agents/Microsoft.Azure.Agent/Command.cs
+++ b/shell/agents/Microsoft.Azure.Agent/Command.cs
@@ -72,13 +72,12 @@ internal sealed class ReplaceCommand : CommandBase
                 var item = items[i];
                 var (command, parameter) = dataRetriever.GetMappedCommand(item.Name);
 
-                string desc = item.Desc.TrimEnd('.');
-                string coloredCmd = parameter is null ? null : SyntaxHighlightAzCommand(command, parameter, item.Name);
-                string cmdPart = coloredCmd is null ? null : $" [{coloredCmd}]";
-
-                host.WriteLine(item.Type is "string"
-                    ? $"{i+1}. {desc}{cmdPart}"
-                    : $"{i+1}. {desc}{cmdPart}. Value type: {item.Type}");
+                string caption = parameter is null ? item.Name : SyntaxHighlightAzCommand(command, parameter, item.Name);
+                host.WriteLine($"{i+1}. {caption}");
+                if (item.Name != item.Desc)
+                {
+                    host.WriteLine(item.Desc);
+                }
 
                 // Get the task for creating the 'ArgumentInfo' object and show a spinner
                 // if we have to wait for the task to complete.
@@ -109,6 +108,13 @@ internal sealed class ReplaceCommand : CommandBase
                 string value = host.PromptForArgument(argInfo, printCaption: false);
                 if (!string.IsNullOrEmpty(value))
                 {
+                    // Add quotes for the value if needed.
+                    value = value.Trim();
+                    if (value.StartsWith('-') || value.Contains(' '))
+                    {
+                        value = $"\"{value}\"";
+                    }
+
                     _values.Add(item.Name, value);
                     _agent.SaveUserValue(item.Name, value);
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Simplify parameter injection UI and fix a few bugs.
- Stop showing the parameter description from the help cache.
- Stop showing the naming restrictions, and simplify the pattern recommendation.
- Use the command snippet as the caption with the short description generated by GPT.
- Fix the value replacement code to set `Updated` correctly
- Fix the placeholder-parameter pairing code to handle the case where a code block contains multiple `az` commands.

![image](https://github.com/user-attachments/assets/f63dab12-1ada-41b0-b5e2-b8a8cf288878)

