### PR TITLE
Use more concise spinner for 'Azure' agent

### DIFF
--- a/shell/AIShell.Integration/AIShell.Integration.csproj
+++ b/shell/AIShell.Integration/AIShell.Integration.csproj
@@ -22,8 +22,8 @@
 
   <ItemGroup>
     <Content Include="AIShell.psd1;AIShell.psm1">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToPublishDirectory>Always</CopyToPublishDirectory>
     </Content>
   </ItemGroup>
 

--- a/shell/agents/Microsoft.Azure.Agent/AzureAgent.cs
+++ b/shell/agents/Microsoft.Azure.Agent/AzureAgent.cs
@@ -101,6 +101,7 @@ public sealed class AzureAgent : ILLMAgent
             string query = $"{input}\n\n---\n\n{_instructions}";
             CopilotResponse copilotResponse = await host.RunWithSpinnerAsync(
                 status: "Thinking ...",
+                spinnerKind: SpinnerKind.Processing,
                 func: async context => await _chatSession.GetChatResponseAsync(query, context, token)
             ).ConfigureAwait(false);
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Use more concise spinner for 'Azure' agent because the status update message from Azure Copilot could be long.