### PR TITLE
Move away from the local cache files to the Az CLI metadata service

### DIFF
--- a/shell/agents/Microsoft.Azure.Agent/ChatSession.cs
+++ b/shell/agents/Microsoft.Azure.Agent/ChatSession.cs
@@ -23,10 +23,10 @@ internal class ChatSession : IDisposable
     private readonly HttpClient _httpClient;
     private readonly Dictionary<string, object> _flights;
 
-    internal ChatSession()
+    internal ChatSession(HttpClient httpClient)
     {
         _dl_secret = Environment.GetEnvironmentVariable("DL_SECRET");
-        _httpClient = new HttpClient();
+        _httpClient = httpClient;
 
         // Keys and values for flights are from the portal request.
         _flights = new Dictionary<string, object>()
@@ -199,14 +199,14 @@ internal class ChatSession : IDisposable
             text = input,
             attachments = new object[] {
                 new {
-                    contentType = "application/json",
+                    contentType = Utils.JsonContentType,
                     name = "azurecopilot/clienthandlerdefinitions",
                     content =  new {
                         clientHandlers = Array.Empty<object>()
                     }
                 },
                 new {
-                    contentType = "application/json",
+                    contentType = Utils.JsonContentType,
                     name = "azurecopilot/viewcontext",
                     content = new {
                         viewContext = new {
@@ -217,7 +217,7 @@ internal class ChatSession : IDisposable
                     }
                 },
                 new {
-                    contentType = "application/json",
+                    contentType = Utils.JsonContentType,
                     name = "azurecopilot/flights",
                     content = new {
                         flights = _flights
@@ -227,7 +227,7 @@ internal class ChatSession : IDisposable
         };
 
         var json = JsonSerializer.Serialize(requestData, Utils.JsonOptions);
-        var content = new StringContent(json, Encoding.UTF8, "application/json");
+        var content = new StringContent(json, Encoding.UTF8, Utils.JsonContentType);
         var request = new HttpRequestMessage(HttpMethod.Post, _conversationUrl) { Content = content };
 
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _token);
@@ -305,7 +305,6 @@ internal class ChatSession : IDisposable
 
     public void Dispose()
     {
-        _httpClient.Dispose();
         _copilotReceiver?.Dispose();
     }
 }

--- a/shell/agents/Microsoft.Azure.Agent/Schema.cs
+++ b/shell/agents/Microsoft.Azure.Agent/Schema.cs
@@ -224,19 +224,50 @@ internal class ResponseData
 
 internal class ArgumentPlaceholder
 {
-    internal ArgumentPlaceholder(string query, ResponseData data)
+    internal ArgumentPlaceholder(string query, ResponseData data, HttpClient httpClient)
     {
         ArgumentException.ThrowIfNullOrEmpty(query);
         ArgumentNullException.ThrowIfNull(data);
 
         Query = query;
         ResponseData = data;
-        DataRetriever = new(data);
+        DataRetriever = new(data, httpClient);
     }
 
     public string Query { get; set; }
     public ResponseData ResponseData { get; set; }
     public DataRetriever DataRetriever { get; }
+}
+
+internal class AzCLIParameter
+{
+    public List<string> Options { get; set; }
+    public List<string> Choices { get; set; }
+    public bool Required { get; set; }
+
+    [JsonPropertyName("has_completer")]
+    public bool HasCompleter { get; set; }
+}
+
+internal class AzCLICommand
+{
+    public List<AzCLIParameter> Parameters { get; set; }
+
+    public AzCLIParameter FindParameter(string name)
+    {
+        foreach (var param in Parameters)
+        {
+            foreach (var option in param.Options)
+            {
+                if (option.Equals(name, StringComparison.OrdinalIgnoreCase))
+                {
+                    return param;
+                }
+            }
+        }
+
+        return null;
+    }
 }
 
 #endregion

--- a/shell/agents/Microsoft.Azure.Agent/Utils.cs
+++ b/shell/agents/Microsoft.Azure.Agent/Utils.cs
@@ -4,6 +4,8 @@ namespace Microsoft.Azure.Agent;
 
 internal static class Utils
 {
+    internal const string JsonContentType = "application/json";
+
     private static readonly JsonSerializerOptions s_jsonOptions;
     private static readonly JsonSerializerOptions s_humanReadableOptions;
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Move away from the local cache files to the Az CLI metadata service

- Use a single `HttpClient` instance for all requests sent from the `Azure` agent.
- Replace the local cache files with the AzCLI metadata service for static argument values.
  - the timeout for querying the metadata service is set to 1.2 seconds
  - proceed to Az CLI tab completion for dynamic values only if the parameter has completer or if the metadata for the parameter is unavailable