### PR TITLE
Add basic logging for error cases in the Azure agent

### DIFF
--- a/shell/agents/Microsoft.Azure.Agent/AzureCopilotReceiver.cs
+++ b/shell/agents/Microsoft.Azure.Agent/AzureCopilotReceiver.cs
@@ -66,7 +66,7 @@ internal class AzureCopilotReceiver : IDisposable
 
             if (closingMessage is not null)
             {
-                Log.Error("[AzureCopilotReceiver] Sending web socket closing request, message: '{}'", closingMessage);
+                Log.Error("[AzureCopilotReceiver] Sending web socket closing request, message: '{0}'", closingMessage);
                 await _webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, closingMessage, CancellationToken.None);
                 _activityQueue.CompleteAdding();
                 break;

--- a/shell/agents/Microsoft.Azure.Agent/ChatSession.cs
+++ b/shell/agents/Microsoft.Azure.Agent/ChatSession.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+
 using AIShell.Abstraction;
 
 namespace Microsoft.Azure.Agent;
@@ -75,8 +76,7 @@ internal class ChatSession : IDisposable
             else
             {
                 host.WriteErrorLine()
-                    .WriteErrorLine($"Failed to start a conversation due to the following error: {e.Message}")
-                    .WriteErrorLine(e.StackTrace)
+                    .WriteErrorLine($"Failed to start a conversation due to the following error: {e.Message}\n{e.StackTrace}")
                     .WriteErrorLine()
                     .WriteErrorLine("Please try '/refresh' to start a new conversation.")
                     .WriteErrorLine();

--- a/shell/agents/Microsoft.Azure.Agent/DataRetriever.cs
+++ b/shell/agents/Microsoft.Azure.Agent/DataRetriever.cs
@@ -575,7 +575,7 @@ internal class DataRetriever : IDisposable
             else
             {
                 // TODO: telemetry.
-                Log.Error("[QueryForMetadata] Metadata service returns status code: {0}. Query command: {1}", response.StatusCode, azCommand);
+                Log.Error("[QueryForMetadata] Received status code '{0}' for command '{1}'", response.StatusCode, azCommand);
             }
         }
         catch (Exception e)

--- a/shell/agents/Microsoft.Azure.Agent/DataRetriever.cs
+++ b/shell/agents/Microsoft.Azure.Agent/DataRetriever.cs
@@ -4,7 +4,9 @@ using System.Diagnostics;
 using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+
 using AIShell.Abstraction;
+using Serilog;
 
 namespace Microsoft.Azure.Agent;
 
@@ -573,11 +575,13 @@ internal class DataRetriever : IDisposable
             else
             {
                 // TODO: telemetry.
+                Log.Error("[QueryForMetadata] Metadata service returns status code: {0}. Query command: {1}", response.StatusCode, azCommand);
             }
         }
-        catch (Exception)
+        catch (Exception e)
         {
             // TODO: telemetry.
+            Log.Error(e, "[QueryForMetadata] Exception while processing command: {0}", azCommand);
         }
 
         return command;

--- a/shell/agents/Microsoft.Azure.Agent/Microsoft.Azure.Agent.csproj
+++ b/shell/agents/Microsoft.Azure.Agent/Microsoft.Azure.Agent.csproj
@@ -18,6 +18,8 @@
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.11.4" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.Async" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Add basic logging for error cases in the Azure agent.
- Use `Serilog` as it supports file logging. I considered `Microsoft.Extension.Logging` which has built-in logging provider for Event Source, but decided to not use it because it's easier to share a file log for diagnosis purposes.
- The logging is configured to be rolling over by day, and it uses async writing to the log file.
- The logging enabled so far is error only, but we can add more information/debug loggings for better view of the code operation.
- We will need to allow a user to disable logging in the agent's configuration file. **This is not done in this PR.**


