### PR TITLE
Expose more states to prepare for telemetry collection

### DIFF
--- a/shell/agents/Microsoft.Azure.Agent/Schema.cs
+++ b/shell/agents/Microsoft.Azure.Agent/Schema.cs
@@ -102,30 +102,28 @@ internal class ConversationState
 
 internal class CopilotResponse
 {
-    internal CopilotResponse(ChunkReader chunkReader, string locale, string topicName)
+    internal CopilotResponse(CopilotActivity activity, ChunkReader chunkReader)
+        : this(activity)
     {
         ArgumentNullException.ThrowIfNull(chunkReader);
-        ArgumentException.ThrowIfNullOrEmpty(topicName);
-
         ChunkReader = chunkReader;
-        Locale = locale;
-        TopicName = topicName;
     }
 
-    internal CopilotResponse(string text, string locale, string topicName)
+    internal CopilotResponse(CopilotActivity activity)
     {
-        ArgumentException.ThrowIfNullOrEmpty(text);
-        ArgumentException.ThrowIfNullOrEmpty(topicName);
+        ArgumentNullException.ThrowIfNull(activity);
 
-        Text = text;
-        Locale = locale;
-        TopicName = topicName;
+        Text = activity.Text;
+        Locale = activity.Locale;
+        TopicName = activity.TopicName;
+        ReplyToId = activity.ReplyToId;
     }
 
     internal ChunkReader ChunkReader { get; }
     internal string Text { get; }
     internal string Locale { get; }
     internal string TopicName { get; }
+    internal string ReplyToId { get; }
     internal string[] SuggestedUserResponses { get; set; }
     internal ConversationState ConversationState { get; set; }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Expose more states to prepare for telemetry collection
- `CopilotResponse` received from a chat is now saved in a private member of the agent, so its states could be used by telemetry.
- Offer the `ConversationId` property in `ChatSession` for getting the current conversation id.
- Expose `ReplyToId` in `CopilotResponse`, which is the activity id of the user's query that the current response replies to.
