### PR TITLE
Add some more logging entries and support agent settings

### DIFF
--- a/shell/agents/Microsoft.Azure.Agent/AzureCopilotReceiver.cs
+++ b/shell/agents/Microsoft.Azure.Agent/AzureCopilotReceiver.cs
@@ -43,6 +43,8 @@ internal class AzureCopilotReceiver : IDisposable
 
     private async Task ProcessActivities()
     {
+        Log.Debug("[AzureCopilotReceiver] Receiver is up and running.");
+
         while (_webSocket.State is WebSocketState.Open)
         {
             string closingMessage = null;
@@ -55,18 +57,18 @@ internal class AzureCopilotReceiver : IDisposable
                 {
                     closingMessage = "Close message received";
                     _activityQueue.Add(new CopilotActivity { Error = new ConnectionDroppedException("The server websocket is closing. Connection dropped.") });
+                    Log.Information("[AzureCopilotReceiver] Web socket closed by server.");
                 }
             }
             catch (OperationCanceledException)
             {
                 // Close the web socket before the thread is going away.
                 closingMessage = "Client closing";
-                Log.Error("[AzureCopilotReceiver] Receiver thread cancelled, which means the instance was disposed.");
+                Log.Information("[AzureCopilotReceiver] Receiver was cancelled and disposed.");
             }
 
             if (closingMessage is not null)
             {
-                Log.Error("[AzureCopilotReceiver] Sending web socket closing request, message: '{0}'", closingMessage);
                 await _webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, closingMessage, CancellationToken.None);
                 _activityQueue.CompleteAdding();
                 break;

--- a/shell/agents/Microsoft.Azure.Agent/ChatSession.cs
+++ b/shell/agents/Microsoft.Azure.Agent/ChatSession.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 
 using AIShell.Abstraction;
+using Serilog;
 
 namespace Microsoft.Azure.Agent;
 
@@ -144,6 +145,8 @@ internal class ChatSession : IDisposable
         _streamUrl = spl.StreamUrl;
         _expireOn = DateTime.UtcNow.AddSeconds(spl.ExpiresIn);
         _copilotReceiver = await AzureCopilotReceiver.CreateAsync(_streamUrl);
+
+        Log.Debug("[ChatSession] Conversation started. Id: {0}", _conversationId);
 
         while (true)
         {

--- a/shell/agents/Microsoft.Azure.Agent/DataRetriever.cs
+++ b/shell/agents/Microsoft.Azure.Agent/DataRetriever.cs
@@ -433,6 +433,7 @@ internal class DataRetriever : IDisposable
         // Handle non-AzCLI command.
         if (pair.Parameter is null)
         {
+            Log.Debug("[DataRetriever] Non-AzCLI command: '{0}'", pair.Command);
             return new ArgumentInfo(item.Name, item.Desc, dataType);
         }
 
@@ -480,6 +481,8 @@ internal class DataRetriever : IDisposable
         // Then, try to get dynamic argument values using AzCLI tab completion.
         string commandLine = $"{pair.Command} {pair.Parameter} ";
         string tempFile = Path.GetTempFileName();
+
+        Log.Debug("[DataRetriever] Perform tab completion for '{0}'", commandLine);
 
         try
         {

--- a/shell/agents/Microsoft.Azure.Agent/Schema.cs
+++ b/shell/agents/Microsoft.Azure.Agent/Schema.cs
@@ -1,9 +1,55 @@
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using AIShell.Abstraction;
 
 namespace Microsoft.Azure.Agent;
+
+internal class AgentSetting
+{
+    public bool Logging { get; set; }
+    public bool Telemetry { get; set; }
+
+    public AgentSetting()
+    {
+        // Enable logging and telemetry by default.
+        Logging = true;
+        Telemetry = true;
+    }
+
+    internal static AgentSetting Default => new();
+
+    internal static AgentSetting LoadFromFile(string path)
+    {
+        FileInfo file = new(path);
+        if (file.Exists)
+        {
+            try
+            {
+                using var stream = file.OpenRead();
+                return JsonSerializer.Deserialize<AgentSetting>(stream, Utils.JsonOptions);
+            }
+            catch (Exception e)
+            {
+                throw new InvalidDataException($"Parsing settings from '{path}' failed with the following error: {e.Message}", e);
+            }
+        }
+
+        return null;
+    }
+
+    internal static void NewSettingFile(string path)
+    {
+        const string content = """
+            {
+              "logging": true,
+              "telemetry": true
+            }
+            """;
+        File.WriteAllText(path, content, Encoding.UTF8);
+    }
+}
 
 internal class TokenPayload
 {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Add some more logging entries and support agent settings

- Add a few more logging entries at the `Debug` level
- Add support for the agent setting, initially with 2 properties only: `logging` and `telemetry`, both are boolean values.
- By default, `logging` and `telemetry` are both `true`, meaning both are enabled.
- A new config file will be created if it doesn't exist, and the default values will be used.
