### PR TITLE
Add authentication to the `Azure` agent

### DIFF
--- a/shell/AIShell.Abstraction/ILLMAgent.cs
+++ b/shell/AIShell.Abstraction/ILLMAgent.cs
@@ -137,11 +137,12 @@ public interface ILLMAgent : IDisposable
     void Initialize(AgentConfig config);
 
     /// <summary>
-    /// Refresh the current chat by starting a new chat session.
+    /// Refresh the current chat or force starting a new chat session.
     /// This method allows an agent to reset chat states, interact with user for authentication, print welcome message, and more.
     /// </summary>
     /// <param name="shell">The interface for interacting with the shell.</param>
-    Task RefreshChatAsync(IShell shell);
+    /// <param name="force">Whether or not to force creating a new chat session.</param>
+    Task RefreshChatAsync(IShell shell, bool force);
 
     /// <summary>
     /// Initiates a chat with the AI, using the provided input and shell.

--- a/shell/AIShell.Kernel/Command/RefreshCommand.cs
+++ b/shell/AIShell.Kernel/Command/RefreshCommand.cs
@@ -19,6 +19,6 @@ internal sealed class RefreshCommand : CommandBase
         var shell = (Shell)Shell;
         shell.ShowBanner();
         shell.ShowLandingPage();
-        shell.ActiveAgent.Impl.RefreshChatAsync(Shell).GetAwaiter().GetResult();
+        shell.ActiveAgent.Impl.RefreshChatAsync(Shell, force: true).GetAwaiter().GetResult();
     }
 }

--- a/shell/AIShell.Kernel/Shell.cs
+++ b/shell/AIShell.Kernel/Shell.cs
@@ -555,7 +555,7 @@ internal sealed class Shell : IShell
                 if (_shouldRefresh)
                 {
                     _shouldRefresh = false;
-                    await agent?.Impl.RefreshChatAsync(this);
+                    await agent?.Impl.RefreshChatAsync(this, force: false);
                 }
 
                 if (Regenerate)
@@ -670,7 +670,7 @@ internal sealed class Shell : IShell
 
         try
         {
-            await _activeAgent.Impl.RefreshChatAsync(this);
+            await _activeAgent.Impl.RefreshChatAsync(this, force: false);
             await _activeAgent.Impl.ChatAsync(prompt, this);
         }
         catch (OperationCanceledException)

--- a/shell/agents/AIShell.Azure.Agent/AzCLI/AzCLIAgent.cs
+++ b/shell/agents/AIShell.Azure.Agent/AzCLI/AzCLIAgent.cs
@@ -101,7 +101,7 @@ public sealed class AzCLIAgent : ILLMAgent
             });
     }
 
-    public Task RefreshChatAsync(IShell shell)
+    public Task RefreshChatAsync(IShell shell, bool force)
     {
         // Reset the history so the subsequent chat can start fresh.
         _chatService.ChatHistory.Clear();

--- a/shell/agents/AIShell.Azure.Agent/AzPS/AzPSAgent.cs
+++ b/shell/agents/AIShell.Azure.Agent/AzPS/AzPSAgent.cs
@@ -105,7 +105,7 @@ public sealed class AzPSAgent : ILLMAgent
             });
     }
 
-    public Task RefreshChatAsync(IShell shell)
+    public Task RefreshChatAsync(IShell shell, bool force)
     {
         // Reset the history so the subsequent chat can start fresh.
         _chatService.ChatHistory.Clear();

--- a/shell/agents/AIShell.Interpreter.Agent/Agent.cs
+++ b/shell/agents/AIShell.Interpreter.Agent/Agent.cs
@@ -72,7 +72,7 @@ public sealed class InterpreterAgent : ILLMAgent
     }
 
     /// <inheritdoc/>
-    public Task RefreshChatAsync(IShell shell)
+    public Task RefreshChatAsync(IShell shell, bool force)
     {
         // Reload the setting file if needed.
         ReloadSettings();

--- a/shell/agents/AIShell.Ollama.Agent/OllamaAgent.cs
+++ b/shell/agents/AIShell.Ollama.Agent/OllamaAgent.cs
@@ -87,7 +87,7 @@ public sealed class OllamaAgent : ILLMAgent
     /// Refresh the current chat by starting a new chat session.
     /// This method allows an agent to reset chat states, interact with user for authentication, print welcome message, and more.
     /// </summary>
-    public Task RefreshChatAsync(IShell shell) => Task.CompletedTask;
+    public Task RefreshChatAsync(IShell shell, bool force) => Task.CompletedTask;
 
     /// <summary>
     /// Main chat function that takes the users input and passes it to the LLM and renders it.

--- a/shell/agents/AIShell.OpenAI.Agent/Agent.cs
+++ b/shell/agents/AIShell.OpenAI.Agent/Agent.cs
@@ -77,7 +77,7 @@ public sealed class OpenAIAgent : ILLMAgent
     public void OnUserAction(UserActionPayload actionPayload) {}
 
     /// <inheritdoc/>
-    public Task RefreshChatAsync(IShell shell)
+    public Task RefreshChatAsync(IShell shell, bool force)
     {
         // Reload the setting file if needed.
         ReloadSettings();

--- a/shell/agents/Microsoft.Azure.Agent/AzureAgent.cs
+++ b/shell/agents/Microsoft.Azure.Agent/AzureAgent.cs
@@ -2,6 +2,7 @@
 using System.Text;
 
 using AIShell.Abstraction;
+using Azure.Identity;
 using Serilog;
 
 namespace Microsoft.Azure.Agent;
@@ -115,10 +116,45 @@ public sealed class AzureAgent : ILLMAgent
     public bool CanAcceptFeedback(UserAction action) => false;
     public void OnUserAction(UserActionPayload actionPayload) {}
 
-    public async Task RefreshChatAsync(IShell shell)
+    public async Task RefreshChatAsync(IShell shell, bool force)
     {
-        // Refresh the chat session.
-        await _chatSession.RefreshAsync(shell.Host, shell.CancellationToken);
+        IHost host = shell.Host;
+        CancellationToken cancellationToken = shell.CancellationToken;
+
+        while (!Debugger.IsAttached)
+        {
+            Thread.Sleep(300);
+        }
+        Debugger.Break();
+
+        try
+        {
+            string welcome = await host.RunWithSpinnerAsync(
+                status: "Initializing ...",
+                spinnerKind: SpinnerKind.Processing,
+                func: async context => await _chatSession.RefreshAsync(context, force, cancellationToken)
+            ).ConfigureAwait(false);
+
+            if (!string.IsNullOrEmpty(welcome))
+            {
+                host.WriteLine(welcome);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            host.WriteErrorLine("Operation cancelled. Please run '/refresh' to start a new conversation.");
+        }
+        catch (CredentialUnavailableException)
+        {
+            host.WriteErrorLine($"Failed to start a chat session: Access token not available.");
+            host.WriteErrorLine($"The '{Name}' agent depends on the Azure CLI credential to acquire access token. Please run 'az login' from a command-line shell to setup account.");
+        }
+        catch (Exception e)
+        {
+            host.WriteErrorLine($"Failed to start a chat session: {e.Message}\n{e.StackTrace}")
+                .WriteErrorLine()
+                .WriteErrorLine("Please try '/refresh' to start a new conversation.");
+        }
     }
 
     public async Task<bool> ChatAsync(string input, IShell shell)

--- a/shell/agents/Microsoft.Azure.Agent/AzureAgent.cs
+++ b/shell/agents/Microsoft.Azure.Agent/AzureAgent.cs
@@ -121,12 +121,6 @@ public sealed class AzureAgent : ILLMAgent
         IHost host = shell.Host;
         CancellationToken cancellationToken = shell.CancellationToken;
 
-        while (!Debugger.IsAttached)
-        {
-            Thread.Sleep(300);
-        }
-        Debugger.Break();
-
         try
         {
             string welcome = await host.RunWithSpinnerAsync(

--- a/shell/agents/Microsoft.Azure.Agent/Command.cs
+++ b/shell/agents/Microsoft.Azure.Agent/Command.cs
@@ -110,7 +110,7 @@ internal sealed class ReplaceCommand : CommandBase
                 {
                     // Add quotes for the value if needed.
                     value = value.Trim();
-                    if (value.StartsWith('-') || value.Contains(' '))
+                    if (value.StartsWith('-') || value.Contains(' ') || value.Contains('|'))
                     {
                         value = $"\"{value}\"";
                     }

--- a/shell/agents/Microsoft.Azure.Agent/Schema.cs
+++ b/shell/agents/Microsoft.Azure.Agent/Schema.cs
@@ -51,13 +51,35 @@ internal class AgentSetting
     }
 }
 
-internal class TokenPayload
+internal enum TokenHealth
+{
+    Good,
+    TimeToRefresh,
+    Expired
+}
+
+internal class RefreshDLToken
 {
     public string ConversationId { get; set; }
     public string Token { get; set; }
 
     [JsonPropertyName("expires_in")]
     public int ExpiresIn { get; set; }
+}
+
+internal class NewDLToken
+{
+    public string Endpoint { get; set; }
+    public string Token { get; set; }
+    public int TokenExpiryTimeInSeconds { get; set; }
+}
+
+internal class DirectLineToken
+{
+    public string Id { get; set; }
+    public DateTime CreatedAt { get; set; }
+    public DateTime LastModifiedAt { get; set; }
+    public NewDLToken DirectLine { get; set; }
 }
 
 internal class SessionPayload

--- a/shell/shell.common.props
+++ b/shell/shell.common.props
@@ -8,7 +8,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>12.0</LangVersion>
-    <Version>0.1.0-alpha.16</Version>
+    <Version>0.1.0-alpha.19</Version>
 
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Add authentication to the `Azure` agent.
- Generate DL token using the new "conversation start" API
- Refresh token potentially before each query
- Update the interface method `RefreshChatAsync` to take another parameter `bool force`, to indicate whether or not to force creating a new chat session. Only `/refresh` command will call this method with `force = true`, because that's an explicit action from user to refresh the current chat session. In other cases, it's up to the agent to decide how it want to do the refreshing, for example, refreshing the token only, or reload the setting.
  - This change is required by the `Azure` agent. A user only gets fixed number of chat sessions per day, so we don't want to keep creating new chat sessions when user is simply switching agents.
  - For a soft refresh, the `Azure` agent will try refreshing the DL token if there is an existing chat session, and otherwise, it starts a new chat session.
  - For a hard refresh (forced), the `Azure` agent will end the current chat session if there is one and start a new chat session.