### PR TITLE
Multiple fixes and UI improvements based on feedback

### DIFF
--- a/shell/AIShell.Abstraction/ILLMAgent.cs
+++ b/shell/AIShell.Abstraction/ILLMAgent.cs
@@ -138,7 +138,7 @@ public interface ILLMAgent : IDisposable
 
     /// <summary>
     /// Refresh the current chat or force starting a new chat session.
-    /// This method allows an agent to reset chat states, interact with user for authentication, print welcome message, and more.
+    /// This method allows an agent to reset chat states, refresh token or settings, interact with user for authentication, print welcome message, and more.
     /// </summary>
     /// <param name="shell">The interface for interacting with the shell.</param>
     /// <param name="force">Whether or not to force creating a new chat session.</param>

--- a/shell/AIShell.Kernel/LLMAgent.cs
+++ b/shell/AIShell.Kernel/LLMAgent.cs
@@ -13,7 +13,7 @@ internal class LLMAgent
     {
         Impl = agent;
         LoadContext = loadContext;
-        Prompt = agent.Name;
+        Prompt = $"@{agent.Name}";
     }
 
     internal void Display(Host host, string description = null)

--- a/shell/AIShell.Kernel/Shell.cs
+++ b/shell/AIShell.Kernel/Shell.cs
@@ -285,7 +285,7 @@ internal sealed class Shell : IShell
             chosenAgent ??= _agents.Count is 1
                 ? _agents[0]
                 : Host.PromptForSelectionAsync(
-                    title: "[orange1]Please select an [Blue]agent[/] to use[/]:\n[grey](You can switch to another agent later by [Blue]@[/] tagging its name)[/]",
+                    title: "[orange1]Please select an [Blue]agent[/] to use[/]:\n[grey](You can switch to another agent later by typing [Blue]@<agent name>[/])[/]",
                     choices: _agents,
                     converter: static a => a.Impl.Name)
                 .GetAwaiter().GetResult();

--- a/shell/AIShell.Kernel/Shell.cs
+++ b/shell/AIShell.Kernel/Shell.cs
@@ -606,7 +606,7 @@ internal sealed class Shell : IShell
                     else
                     {
                         // We may be switching to an agent that hasn't setup its chat session yet.
-                        // So, give it a chance to do so in that case.
+                        // So, give it a chance to do so before calling its 'Chat' method.
                         await RefreshChatAsNeeded(agent);
                     }
                 }

--- a/shell/agents/AIShell.Interpreter.Agent/Agent.cs
+++ b/shell/agents/AIShell.Interpreter.Agent/Agent.cs
@@ -74,12 +74,15 @@ public sealed class InterpreterAgent : ILLMAgent
     /// <inheritdoc/>
     public Task RefreshChatAsync(IShell shell, bool force)
     {
-        // Reload the setting file if needed.
-        ReloadSettings();
-        // Reset the history so the subsequent chat can start fresh.
-        _chatService.RefreshChat();
-        // Shut down the execution service to start fresh.
-        _executionService.Terminate();
+        if (force)
+        {
+            // Reload the setting file if needed.
+            ReloadSettings();
+            // Reset the history so the subsequent chat can start fresh.
+            _chatService.RefreshChat();
+            // Shut down the execution service to start fresh.
+            _executionService.Terminate();
+        }
 
         return Task.CompletedTask;
     }

--- a/shell/agents/AIShell.OpenAI.Agent/Agent.cs
+++ b/shell/agents/AIShell.OpenAI.Agent/Agent.cs
@@ -79,10 +79,13 @@ public sealed class OpenAIAgent : ILLMAgent
     /// <inheritdoc/>
     public Task RefreshChatAsync(IShell shell, bool force)
     {
-        // Reload the setting file if needed.
-        ReloadSettings();
-        // Reset the history so the subsequent chat can start fresh.
-        _chatService.ChatHistory.Clear();
+        if (force)
+        {
+            // Reload the setting file if needed.
+            ReloadSettings();
+            // Reset the history so the subsequent chat can start fresh.
+            _chatService.ChatHistory.Clear();
+        }
 
         return Task.CompletedTask;
     }

--- a/shell/agents/Microsoft.Azure.Agent/AzureAgent.cs
+++ b/shell/agents/Microsoft.Azure.Agent/AzureAgent.cs
@@ -77,7 +77,7 @@ public sealed class AzureAgent : ILLMAgent
 
     public void Dispose()
     {
-        ArgPlaceholder?.DataRetriever?.Dispose();
+        ResetArgumentPlaceholder();
         _chatSession.Dispose();
         _httpClient.Dispose();
 
@@ -120,6 +120,7 @@ public sealed class AzureAgent : ILLMAgent
     {
         IHost host = shell.Host;
         CancellationToken cancellationToken = shell.CancellationToken;
+        ResetArgumentPlaceholder();
 
         try
         {
@@ -179,8 +180,7 @@ public sealed class AzureAgent : ILLMAgent
 
             if (_copilotResponse.ChunkReader is null)
             {
-                ArgPlaceholder?.DataRetriever?.Dispose();
-                ArgPlaceholder = null;
+                ResetArgumentPlaceholder();
 
                 // Process CLI handler response specially to support parameter injection.
                 ResponseData data = null;
@@ -360,6 +360,12 @@ public sealed class AzureAgent : ILLMAgent
         return data;
     }
 
+    internal void ResetArgumentPlaceholder()
+    {
+        ArgPlaceholder?.DataRetriever?.Dispose();
+        ArgPlaceholder = null;
+    }
+
     internal void SaveUserValue(string phName, string value)
     {
         ArgumentException.ThrowIfNullOrEmpty(phName);
@@ -465,7 +471,9 @@ public sealed class AzureAgent : ILLMAgent
                     _buffer.Append($"- `{phItem.Name}`: {phItem.Desc}\n");
                 }
 
-                _buffer.Append("\nRun `/replace` to get assistance in placeholder replacement.\n");
+                // Use green (0,195,0) on grey (48,48,48) for rendering the command '/replace'.
+                // TODO: the color formatting should be exposed by the shell as utility method.
+                _buffer.Append("\nRun \x1b[38;2;0;195;0;48;2;48;48;48m /replace \x1b[0m to get assistance in placeholder replacement.\n");
             }
         }
 

--- a/shell/agents/Microsoft.Azure.Agent/ChatSession.cs
+++ b/shell/agents/Microsoft.Azure.Agent/ChatSession.cs
@@ -70,7 +70,7 @@ internal class ChatSession : IDisposable
             if (force)
             {
                 // End the existing conversation.
-                context.Status("End current chat ...");
+                context.Status("Ending current chat ...");
                 EndConversation();
                 Reset();
             }
@@ -78,7 +78,7 @@ internal class ChatSession : IDisposable
             {
                 try
                 {
-                    context.Status("Refresh DirectLine token ...");
+                    context.Status("Refreshing token ...");
                     await RenewTokenAsync(cancellationToken);
                     return null;
                 }

--- a/shell/agents/Microsoft.Azure.Agent/Command.cs
+++ b/shell/agents/Microsoft.Azure.Agent/Command.cs
@@ -238,8 +238,7 @@ internal sealed class ReplaceCommand : CommandBase
 
         if (data.PlaceholderSet is null)
         {
-            _agent.ArgPlaceholder.DataRetriever.Dispose();
-            _agent.ArgPlaceholder = null;
+            _agent.ResetArgumentPlaceholder();
         }
 
         return _agent.GenerateAnswer(data);


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Multiple fixes and UI improvements based on feedback

1. Fix a bug when run `@Azure <query>` before the `Azure` agent starts a chat session.
2. Reset argument placeholder information when `RefreshChatAsync` is called on the `Azure` agent.
3. Update the initial agent selection message to let the user know they can switch to another agent later by `@` tagging its name.
4. Update the read-line prompt to start with `@`, like `@Azure> `, so as to make the `@` tagging more obvious.
5. Update the color used for `/replace` in the `Run /replace to get assistance in placeholder replacement` message to be more eye catching.

![image](https://github.com/user-attachments/assets/8b28c74b-b640-43a8-93c4-2d33e400d463)

![image](https://github.com/user-attachments/assets/2a59b7a7-15a9-4612-8351-39608dc51f25)


