### PR TITLE
Reset the `_turnLeft` field of the `azure` agent when a new chat session is created

### DIFF
--- a/shell/agents/Microsoft.Azure.Agent/AzureAgent.cs
+++ b/shell/agents/Microsoft.Azure.Agent/AzureAgent.cs
@@ -56,7 +56,7 @@ public sealed class AzureAgent : ILLMAgent
         _valueStore = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         _instructions = string.Format(InstructionPrompt, Environment.OSVersion.VersionString);
 
-        Name = "Azure";
+        Name = "azure";
         Company = "Microsoft";
         Description = "This AI assistant can generate Azure CLI and Azure PowerShell commands for managing Azure resources, answer questions, and provides information tailored to your specific Azure environment.";
 
@@ -132,6 +132,7 @@ public sealed class AzureAgent : ILLMAgent
 
             if (!string.IsNullOrEmpty(welcome))
             {
+                _turnsLeft = int.MaxValue;
                 host.WriteLine(welcome);
             }
         }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

- Reset the `_turnLeft` field of the `azure` agent when a new chat session is created.
- Rename the agent to be `azure`