### PR TITLE
Handle error message from the Azure Orchestrator

### DIFF
--- a/shell/agents/Microsoft.Azure.Agent/AzureAgent.cs
+++ b/shell/agents/Microsoft.Azure.Agent/AzureAgent.cs
@@ -183,20 +183,29 @@ public sealed class AzureAgent : ILLMAgent
             {
                 ResetArgumentPlaceholder();
 
-                // Process CLI handler response specially to support parameter injection.
-                ResponseData data = null;
-                if (_copilotResponse.TopicName == CopilotActivity.CLIHandlerTopic)
+                if (_copilotResponse.IsError)
                 {
-                    data = ParseCLIHandlerResponse(shell);
+                    host.WriteErrorLine()
+                        .WriteErrorLine(_copilotResponse.Text)
+                        .WriteErrorLine();
                 }
-
-                if (data?.PlaceholderSet is not null)
+                else
                 {
-                    ArgPlaceholder = new ArgumentPlaceholder(input, data, _httpClient);
-                }
+                    // Process CLI handler response specially to support parameter injection.
+                    ResponseData data = null;
+                    if (_copilotResponse.TopicName == CopilotActivity.CLIHandlerTopic)
+                    {
+                        data = ParseCLIHandlerResponse(shell);
+                    }
 
-                string answer = data is null ? _copilotResponse.Text : GenerateAnswer(data);
-                host.RenderFullResponse(answer);
+                    if (data?.PlaceholderSet is not null)
+                    {
+                        ArgPlaceholder = new ArgumentPlaceholder(input, data, _httpClient);
+                    }
+
+                    string answer = data is null ? _copilotResponse.Text : GenerateAnswer(data);
+                    host.RenderFullResponse(answer);
+                }
             }
             else
             {

--- a/shell/agents/Microsoft.Azure.Agent/ChatSession.cs
+++ b/shell/agents/Microsoft.Azure.Agent/ChatSession.cs
@@ -27,8 +27,6 @@ internal class ChatSession : IDisposable
     private readonly HttpClient _httpClient;
     private readonly Dictionary<string, object> _flights;
 
-    internal string ConversationId => _conversationId;
-
     internal ChatSession(HttpClient httpClient)
     {
         _httpClient = httpClient;
@@ -328,6 +326,7 @@ internal class ChatSession : IDisposable
                     {
                         "typing"         => new CopilotResponse(activity, new ChunkReader(_copilotReceiver, activity)),
                         "acceptingInput" => new CopilotResponse(activity),
+                        "error"          => new CopilotResponse(activity) { IsError = true },
                         _ => throw CorruptDataException.Create($"The 'inputHint' is {activity.InputHint}.", activity)
                     };
 
@@ -338,6 +337,7 @@ internal class ChatSession : IDisposable
                         ret.ConversationState = state;
                     }
 
+                    ret.ConversationId = _conversationId;
                     return ret;
                 }
 

--- a/shell/agents/Microsoft.Azure.Agent/Schema.cs
+++ b/shell/agents/Microsoft.Azure.Agent/Schema.cs
@@ -192,6 +192,9 @@ internal class CopilotResponse
     internal string Locale { get; }
     internal string TopicName { get; }
     internal string ReplyToId { get; }
+
+    internal bool IsError { get; set; }
+    internal string ConversationId { get; set; }
     internal string[] SuggestedUserResponses { get; set; }
     internal ConversationState ConversationState { get; set; }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

- Handle error message from the Azure Orchestrator.
- Add `ConversationId` property to the `CopilotResponse` type.

The Azure Orchestrator may return an error message like this:

```json
{
  "type": "message",
  "id": "7zoAgmG58OPJttpKKYnYqZ-us|0000002",
  "timestamp": "2024-10-28T17:59:41.5245466Z",
  "channelId": "directline",
  "from": {
    "id": "copilotweb-canary-prod",
    "name": "copilotweb-canary-prod"
  },
  "topicName": "Orchestrator",
  "text": "Sorry, Copilot encountered an error. Please try again or share your feedback.\nActivityId = 7zoAgmG58OPJttpKKYnYqZ-us|0000001, CorrelationID = 7zoAgmG58OPJttpKKYnYqZ-us|0000001, Timestamp = 2024-10-28T17:59:41.4950709Z",
  "inputHint": "error",
  "locale": "en-US",
  "attachments": [
    {
      "contentType": "azurecopilot/conversationstate",
      "content": {
        "turnLimit": 15,
        "turnNumber": 1,
        "turnLimitMet": false,
        "turnLimitExceeded": false,
        "dailyConversationNumber": 4,
        "dailyConversationLimitMet": false,
        "dailyConversationLimitExceeded": false
      },
      "name": "azurecopilot/conversationstate"
    }
  ],
  "replyToId": "7zoAgmG58OPJttpKKYnYqZ-us|0000001"
}
```

