### PR TITLE
Refactored the authentication flow and add the check for Copilot access

### DIFF
--- a/shell/agents/Microsoft.Azure.Agent/Utils.cs
+++ b/shell/agents/Microsoft.Azure.Agent/Utils.cs
@@ -34,10 +34,26 @@ internal static class Utils
     internal static JsonSerializerOptions JsonOptions => s_jsonOptions;
     internal static JsonSerializerOptions JsonHumanReadableOptions => s_humanReadableOptions;
     internal static JsonSerializerOptions RelaxedJsonEscapingOptions => s_relaxedJsonEscapingOptions;
+
+    internal async static Task EnsureSuccessStatusCodeForTokenRequest(this HttpResponseMessage response, string errorMessage)
+    {
+        if (!response.IsSuccessStatusCode)
+        {
+            string responseText = await response.Content.ReadAsStringAsync(CancellationToken.None);
+            string message = $"{errorMessage} HTTP status: {response.StatusCode}, Response: {responseText}";
+            Telemetry.Trace(AzTrace.Exception(message));
+            throw new TokenRequestException(message);
+        }
+    }
 }
 
 internal class TokenRequestException : Exception
 {
+    /// <summary>
+    /// Access to Copilot was denied.
+    /// </summary>
+    internal bool UserUnauthorized { get; set; }
+
     internal TokenRequestException(string message)
         : base(message)
     {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Refactored the authentication flow and add the check for Copilot access.
- Encapsulated the token life cycle management into separate classes `UserAccessToken` and `UserDirectLineToken`. The health of the token is tracked within those types, which expose the renew method.
  - This is a preparation for using the `pluginstore` feature flag, which requires the client to send user access token along with every request, and that means we need to keep 2 tokens alive.
- Refactored the authentication flow using the new encapsulated tokens.
- Add the step to check if the user has Copilot access.