### PR TITLE
Change to the `canary` Copilot Access endpoint because the production endpoint doesn't work in some regions

### DIFF
--- a/shell/agents/Microsoft.Azure.Agent/ChatSession.cs
+++ b/shell/agents/Microsoft.Azure.Agent/ChatSession.cs
@@ -11,7 +11,10 @@ namespace Microsoft.Azure.Agent;
 
 internal class ChatSession : IDisposable
 {
-    private const string ACCESS_URL = "https://copilotweb.production.portalrp.azure.com/api/access?api-version=2024-09-01";
+    // TODO: production URL not yet working for some regions.
+    // private const string ACCESS_URL = "https://copilotweb.production.portalrp.azure.com/api/access?api-version=2024-09-01";
+    private const string ACCESS_URL = "https://copilotweb.canary.production.portalrp.azure.com/api/access?api-version=2024-09-01";
+
     private const string DL_TOKEN_URL = "https://copilotweb.production.portalrp.azure.com/api/conversations/start?api-version=2024-11-15";
     private const string CONVERSATION_URL = "https://directline.botframework.com/v3/directline/conversations";
 

--- a/shell/agents/Microsoft.Azure.Agent/Utils.cs
+++ b/shell/agents/Microsoft.Azure.Agent/Utils.cs
@@ -40,7 +40,12 @@ internal static class Utils
         if (!response.IsSuccessStatusCode)
         {
             string responseText = await response.Content.ReadAsStringAsync(CancellationToken.None);
-            string message = $"{errorMessage} HTTP status: {response.StatusCode}, Response: {responseText}";
+            if (string.IsNullOrEmpty(responseText))
+            {
+                responseText = "<empty>";
+            }
+
+            string message = $"{errorMessage} HTTP status: {response.StatusCode}, Response: {responseText}.";
             Telemetry.Trace(AzTrace.Exception(message));
             throw new TokenRequestException(message);
         }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

- Change to the `canary` Copilot Access endpoint because the production endpoint doesn't work in some regions.
- Update `EnsureSuccessStatusCodeForTokenRequest` to use `"<empty>"` when the response message is null or empty.
