### PR TITLE
Remove id for correlation from Exception.

### DIFF
--- a/shell/agents/Microsoft.Azure.Agent/Telemetry.cs
+++ b/shell/agents/Microsoft.Azure.Agent/Telemetry.cs
@@ -143,16 +143,13 @@ public class AzTrace
         return null;
     }
 
-    internal static AzTrace Exception(CopilotResponse response, object details)
+    internal static AzTrace Exception(object details)
     {
         if (Telemetry.Enabled)
         {
             return new()
             {
-                EventType = "Exception",
-                QueryId = response?.ReplyToId,
-                TopicName = response?.TopicName,
-                ConversationId = response?.ConversationId,
+                EventType = "AIShell Exception",
                 Details = details
             };
         }
@@ -160,8 +157,6 @@ public class AzTrace
         // Don't create an object when telemetry is disabled.
         return null;
     }
-
-    internal static AzTrace Exception(object details) => Exception(response: null, details);
 }
 
 internal class Telemetry


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->
This PR did:
- Remove id for correlation from Exception. Although The `Exception` can be constructed with `CopilotResponse`, it is always set as `null` in current code base (which also caused the `TopicName` not collected in the Telemetry). As we need user consent to save the IDs and we are not asking for user consent when an error occurs, I think it should be good to just remove the response parameter.
- Make the EventType clearer to easier identify AIShell Exceptions from all exceptions logged, which would make query easier. Because we are sharing 1 app inisghts resource between AIShell and AzPS/ AzCLI Endpoint. (Please feel free to raise any other suggestions, for example shall we create a new column for this? Like {EventType: "Exceprion", ExceptionFrom: "AIShell"}.)

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
