### PR TITLE
Fix a bug to only report unexpected errors in `SetupNewChat`

### DIFF
--- a/shell/agents/Microsoft.Azure.Agent/ChatSession.cs
+++ b/shell/agents/Microsoft.Azure.Agent/ChatSession.cs
@@ -132,8 +132,9 @@ internal class ChatSession : IDisposable
         }
         catch (Exception e)
         {
-            if (e is not OperationCanceledException and TokenRequestException)
+            if (e is not OperationCanceledException and not TokenRequestException)
             {
+                // Trace a telemetry for any unexpected error.
                 Telemetry.Trace(AzTrace.Exception("Failed to setup a new chat session."), e);
             }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Fix a bug to only report unexpected errors in `SetupNewChat`.
The `TokenRequestException` error will be reported before throwing the exception, so we shouldn't report it again.

