### PR TITLE
Improve the path completion and tilde support in path

### DIFF
--- a/shell/AIShell.Integration/AIShell.psd1
+++ b/shell/AIShell.Integration/AIShell.psd1
@@ -7,7 +7,7 @@
     CompanyName = 'Microsoft Corporation'
     Copyright = '(c) Microsoft Corporation. All rights reserved.'
     Description = 'Integration with the AIShell to provide intelligent shell experience'
-    PowerShellVersion = '7.4'
+    PowerShellVersion = '7.4.6'
     FunctionsToExport = @()
     CmdletsToExport = @('Start-AIShell','Invoke-AIShell','Resolve-Error')
     VariablesToExport = '*'

--- a/shell/AIShell.Kernel/Command/CodeCommand.cs
+++ b/shell/AIShell.Kernel/Command/CodeCommand.cs
@@ -25,7 +25,7 @@ internal sealed class CodeCommand : CommandBase
         post.AddArgument(nth);
 
         var append = new Option<bool>("--append", "Append to the end of the file.");
-        var file = new Argument<FileInfo>("file", "The file path to save the code to.");
+        var file = new Argument<string>("file", "The file path to save the code to.");
         save.AddArgument(file);
         save.AddOption(append);
 
@@ -88,7 +88,7 @@ internal sealed class CodeCommand : CommandBase
         shell.OnUserAction(new CodePayload(UserAction.CodeCopy, code));
     }
 
-    private void SaveAction(FileInfo file, bool append)
+    private void SaveAction(string path, bool append)
     {
         var shell = (Shell)Shell;
         var host = shell.Host;
@@ -97,6 +97,22 @@ internal sealed class CodeCommand : CommandBase
         if (code is null)
         {
             host.MarkupLine("[olive]No code snippet available for save.[/]");
+            return;
+        }
+
+        if (string.IsNullOrEmpty(path))
+        {
+            host.WriteErrorLine($"Please specify a file path for saving the code.");
+            return;
+        }
+
+        path = Utils.ResolveTilde(path);
+        FileInfo file = new(path);
+
+        string fullName = file.FullName;
+        if (Directory.Exists(fullName))
+        {
+            host.WriteErrorLine($"The specified path '{fullName}' points to an existing directory. Please specify a file path instead.");
             return;
         }
 

--- a/shell/AIShell.Kernel/Command/CommandRunner.cs
+++ b/shell/AIShell.Kernel/Command/CommandRunner.cs
@@ -35,7 +35,7 @@ internal class CommandRunner
             new RefreshCommand(),
             new RetryCommand(),
             new HelpCommand(),
-            new RenderCommand(),
+            //new RenderCommand(),
         };
 
         LoadCommands(buildin, Core);

--- a/shell/AIShell.Kernel/Command/RenderCommand.cs
+++ b/shell/AIShell.Kernel/Command/RenderCommand.cs
@@ -10,17 +10,33 @@ internal sealed class RenderCommand : CommandBase
     public RenderCommand()
         : base("render", "Render a markdown file, for diagnosis purpose.")
     {
-        var file = new Argument<FileInfo>("file", "The file path to save the code to.");
+        var file = new Argument<string>("file", "The file path to save the code to.");
         var append = new Option<bool>("--streaming", "Render in the streaming manner.");
 
         AddArgument(file);
         AddOption(append);
-        this.SetHandler(SaveAction, file, append);
+        this.SetHandler(RenderAction, file, append);
     }
 
-    private void SaveAction(FileInfo file, bool streaming)
+    private void RenderAction(string path, bool streaming)
     {
         var host = Shell.Host;
+
+        if (string.IsNullOrEmpty(path))
+        {
+            host.WriteErrorLine($"Please specify a file path for rendering its content.");
+            return;
+        }
+
+        path = Utils.ResolveTilde(path);
+        FileInfo file = new(path);
+
+        string fullName = file.FullName;
+        if (Directory.Exists(fullName))
+        {
+            host.WriteErrorLine($"The specified path '{fullName}' points to an existing directory. Please specify a file path instead.");
+            return;
+        }
 
         try
         {

--- a/shell/AIShell.Kernel/Utility/ReadLineHelper.cs
+++ b/shell/AIShell.Kernel/Utility/ReadLineHelper.cs
@@ -89,6 +89,7 @@ internal class ReadLineHelper : IReadLineHelper
     private List<CompletionResult> CompleteFileSystemPath(string wordToComplete)
     {
         bool startsWithTilde = false;
+        bool alreadyQuoted = wordToComplete.Contains(' ');
         string homeDirectory = null;
         List<CompletionResult> result = null;
 
@@ -105,7 +106,7 @@ internal class ReadLineHelper : IReadLineHelper
         string QuoteIfNeeded(string path)
         {
             // Do not add quoting if the original string is already quoted.
-            return !wordToComplete.Contains(' ') && path.Contains(' ') ? $"\"{path}\"" : path;
+            return !alreadyQuoted && path.Contains(' ') ? $"\"{path}\"" : path;
         }
 
         // Add one result to the result list.

--- a/shell/AIShell.Kernel/Utility/Utils.cs
+++ b/shell/AIShell.Kernel/Utility/Utils.cs
@@ -85,6 +85,30 @@ internal static class Utils
     }
 
     /// <summary>
+    /// Try resolving the leading tilde in a path.
+    /// </summary>
+    internal static string ResolveTilde(string path)
+    {
+        if (path.StartsWith('~'))
+        {
+            string home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+
+            if (path.Length is 1)
+            {
+                // The path is just '~'.
+                return home;
+            }
+
+            if (path[1] == Path.DirectorySeparatorChar)
+            {
+                return Path.Join(home, path.AsSpan(2));
+            }
+        }
+
+        return path;
+    }
+
+    /// <summary>
     /// Check if the <paramref name="left"/> contains <paramref name="right"/> regardless of
     /// the leading and trailing space characters on each line if both are multi-line strings.
     /// </summary>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

- Improve the path completion and tilde support in path
  - Make path completion better handle quotes and spaces in the path
  - Make path completion able to work for paths starting with `~`
  - Add support for tilde expansion in the path for `/code save <file-path>`
- Update the minimal PowerShell version required for loading the `AIShell` module
- Comment out the `/render` command, which is for debugging purposes.

