### PR TITLE
Add OS Platform Infromation in Telemetry

### DIFF
--- a/shell/agents/Microsoft.Azure.Agent/Telemetry.cs
+++ b/shell/agents/Microsoft.Azure.Agent/Telemetry.cs
@@ -231,6 +231,7 @@ internal class Telemetry
             ["EventType"] = trace.EventType,
             ["ShellCommand"] = trace.ShellCommand,
             ["Details"] = GetDetailedMessage(trace.Details),
+            ["OSPlatform"] = AzTrace.Platform
         };
 
         if (exception is null)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

<!-- Summarize your PR between here and the checklist. -->
- Updated the telemetry functionality by adding information about the operating system platform. 
- Extracted `GetInstallationId()` and `GetOSPlatform()` to make the `initialize()` more readable. 
- TODO: Update the connect string for app insights. Will do tomorrow when I get my SAW on hand to access AME env.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
