### PR TITLE
Add suggestion to use `/code post` or `/code copy` after parameter injection

### DIFF
--- a/shell/AIShell.Abstraction/IShell.cs
+++ b/shell/AIShell.Abstraction/IShell.cs
@@ -11,6 +11,11 @@ public interface IShell
     IHost Host { get; }
 
     /// <summary>
+    /// Indicates whether the bi-directional channel with an application (e.g. a PowerShell session) has been established.
+    /// </summary>
+    bool ChannelEstablished { get; }
+
+    /// <summary>
     /// The token to indicate cancellation when `Ctrl+c` is pressed by user.
     /// </summary>
     CancellationToken CancellationToken { get; }

--- a/shell/AIShell.Kernel/Shell.cs
+++ b/shell/AIShell.Kernel/Shell.cs
@@ -77,6 +77,7 @@ internal sealed class Shell : IShell
     #region IShell implementation
 
     IHost IShell.Host => Host;
+    bool IShell.ChannelEstablished => Channel is not null;
     CancellationToken IShell.CancellationToken => _cancellationSource.Token;
     List<CodeBlock> IShell.ExtractCodeBlocks(string text, out List<SourceInfo> sourceInfos) => Utils.ExtractCodeBlocks(text, out sourceInfos);
 

--- a/shell/agents/Microsoft.Azure.Agent/Command.cs
+++ b/shell/agents/Microsoft.Azure.Agent/Command.cs
@@ -254,6 +254,6 @@ internal sealed class ReplaceCommand : CommandBase
             _agent.ResetArgumentPlaceholder();
         }
 
-        return _agent.GenerateAnswer(data);
+        return _agent.GenerateAnswer(data, Shell);
     }
 }

--- a/shell/shell.common.props
+++ b/shell/shell.common.props
@@ -8,7 +8,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <LangVersion>12.0</LangVersion>
-    <Version>0.1.0-alpha.19</Version>
+    <Version>0.1.0-alpha.20</Version>
 
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION


<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

- Update `IShell` to expose whether a channel to a shell application has been established.
- Add suggestion to use `/code post` or `/code copy` after parameter injection (placeholder replacement), depending on whether a connected shell is available.

![image](https://github.com/user-attachments/assets/1eb3474b-fbec-49a7-9a3d-c871bfeb0a03)

When no channel is available:
![image](https://github.com/user-attachments/assets/b9d57ca7-e9bb-42a8-9b2c-5a18ca8aa0cf)

When channel is available:
![image](https://github.com/user-attachments/assets/8d11a6bb-04f9-45b2-a1da-21106641587c)
