### PR TITLE
Update the error message when `/replace` cannot do its work

### DIFF
--- a/shell/agents/Microsoft.Azure.Agent/Command.cs
+++ b/shell/agents/Microsoft.Azure.Agent/Command.cs
@@ -58,7 +58,7 @@ internal sealed class ReplaceCommand : CommandBase
             {
                 host.WriteErrorLine("No AI response available.");
             }
-            else if (!cr.Text.Contains("```"))
+            else if (!cr.Text.Contains("```") && !cr.Text.Contains("~~~"))
             {
                 host.WriteErrorLine("The last AI response contains no code in it.");
             }

--- a/shell/agents/Microsoft.Azure.Agent/Command.cs
+++ b/shell/agents/Microsoft.Azure.Agent/Command.cs
@@ -53,7 +53,21 @@ internal sealed class ReplaceCommand : CommandBase
 
         if (ap is null)
         {
-            host.WriteErrorLine("No argument placeholder to replace.");
+            CopilotResponse cr = _agent.CopilotResponse;
+            if (cr is null || cr.IsError)
+            {
+                host.WriteErrorLine("No AI response available.");
+            }
+            else if (!cr.Text.Contains("```"))
+            {
+                host.WriteErrorLine("The last AI response contains no code in it.");
+            }
+            else
+            {
+                Telemetry.Trace(AzTrace.Exception($"'/replace' command unavailable. TopicName: {cr.TopicName}"));
+                host.WriteErrorLine("The '/replace' command is experimental and could not successfully parse the response. This issue may occur intermittently due to specific response conditions.");
+            }
+
             return;
         }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

### PR Summary

Update the error message when `/replace` cannot do its work.


![image](https://github.com/user-attachments/assets/fbac23a9-0b2b-41c9-8557-fcbbefb13b7c)

